### PR TITLE
Fix preview for unshared shared-folder files

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -337,6 +337,9 @@ async function handleToggle(toggle, expiration) {
             </div>`
         : `<span class="text-muted">非共有</span>`;
     }
+
+    // 共有状態が変わった際はプレビューURLも変わるため一覧を再取得
+    await reloadFileList();
   } catch (err) {
     alert("共有切替エラー: " + err.message);
   }


### PR DESCRIPTION
## Summary
- reload file list after toggling share state so preview URLs refresh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859eff3d8ac832c81bae88512a897ae