### PR TITLE
Fix shared folder download URLs

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -381,13 +381,13 @@ def create_app() -> web.Application:
                     await db.commit()
                     f["token"] = token
                 # 2) 共有用URL
-                f["preview_url"]  = f"/shared/download/{token}?dl=1"
-                f["download_url"] = f"/shared/download/{token}?dl=1"
+                f["preview_url"]  = f"/shared/download/{token}"
+                f["download_url"] = f"/shared/download/{token}"
             else:
                 # 非共有時はHMAC付きトークンでプライベートルートを生成
                 private_token = _sign_token(f["id"], now_ts + URL_EXPIRES_SEC)
-                f["preview_url"]  = f"/download/{private_token}?dl=1"
-                f["download_url"] = f"/download/{private_token}?dl=1"
+                f["preview_url"]  = f"/download/{private_token}"
+                f["download_url"] = f"/download/{private_token}"
 
             # 2) ファイル名表示用
             f["original_name"] = f.get("file_name", "")  # partial では {{ f.original_name }} を使うため

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -41,8 +41,8 @@
               <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
-                        onclick="showFull('{{ f.preview_url }}'); return false;">
-                  <img src="{{ f.preview_url }}"
+                        onclick="showFull('{{ f.preview_url }}?preview=1'); return false;">
+                  <img src="{{ f.preview_url }}?preview=1"
                       class="img-fluid rounded"
                       style="max-height:60px;">
                 </button>
@@ -52,8 +52,8 @@
               <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
-                        onclick="showFull('{{ f.preview_url }}', true); return false;">
-                  <video src="{{ f.preview_url }}"
+                        onclick="showFull('{{ f.preview_url }}?preview=1', true); return false;">
+                  <video src="{{ f.preview_url }}?preview=1"
                           class="w-100 h-100 rounded object-fit-cover"
                           style="max-width:60px;max-height:60px;"
                           muted autoplay loop playsinline></video>
@@ -64,7 +64,7 @@
               <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
-                        onclick="window.open('{{ f.preview_url }}?preview=1', '_blank'); return false;">
+                        onclick="window.open('{{ f.preview_url }}', '_blank'); return false;">
                   <i class="bi bi-file-earmark-text" style="font-size:2rem;"></i>
                 </button>
                 <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
@@ -74,7 +74,7 @@
             <td class="text-end" title="{{ f.size }} B">{{ f.size|human_size }}</td>
 
             <td class="text-center">
-              <a href="{{ f.download_url }}?dl=1" download class="btn btn-sm btn-outline-primary ripple" data-mdb-ripple-init title="ダウンロード">
+              <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary ripple" data-mdb-ripple-init title="ダウンロード">
                 <i class="bi bi-download"></i>
               </a>
             </td>


### PR DESCRIPTION
## Summary
- fix shared folder preview/download URLs to avoid duplicated query
- make download button directly fetch file

## Testing
- `python3 -m py_compile web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685a08b98bbc832c91a80625eecba3c8