### PR TITLE
Add CDN preconnect hints

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}Web-Discord-Server{% endblock %}</title>
 
+  <!-- 外部 CDN への接続を事前確立して LCP を改善 -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <!-- MDB UI Kit -->

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}Web-Discord-Server{% endblock %}</title>
 
+  <!-- 外部 CDN への接続を事前確立して LCP を改善 -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <!-- MDB UI Kit -->


### PR DESCRIPTION
## Summary
- improve Largest Contentful Paint by establishing early connections to CDN resources

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a3fe1f4a8832c98ec811ec0272def