### PR TITLE
Implement expiration handling

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS files (
     size          INTEGER NOT NULL,
     sha256        TEXT    NOT NULL,
     uploaded_at   TEXT    NOT NULL,
+    expires_at    INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 """
@@ -197,8 +198,8 @@ class Database:
         """
         await self.conn.execute(
             "INSERT INTO shared_files "
-            "  (id, folder_id, file_name, path, size, is_shared, share_token, uploaded_at) "
-            "VALUES (?,     ?,         ?,         ?,    ?,    1,         NULL,       strftime('%s','now'))",
+            "  (id, folder_id, file_name, path, size, is_shared, share_token, uploaded_at, expires_at) "
+            "VALUES (?,     ?,         ?,         ?,    ?,    1,         NULL,       strftime('%s','now'), 0)",
             (file_id, folder_id, filename, path, os.path.getsize(path)),
         )
         await self.conn.commit()
@@ -275,8 +276,8 @@ class Database:
     ):
         await self.conn.execute(
             """INSERT INTO files
-            (id, user_id, original_name, path, size, sha256, uploaded_at)
-            VALUES (?, ?, ?, ?, ?, ?, strftime('%s','now'))""",
+            (id, user_id, original_name, path, size, sha256, uploaded_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, strftime('%s','now'), 0)""",
             (file_id, user_id, original_name, path, size, sha256),
         )
         await self.conn.commit()

--- a/web/app.py
+++ b/web/app.py
@@ -195,39 +195,19 @@ def create_app() -> web.Application:
         token = d.get("token")
 
         # DBに保存されたTTL（秒）をプリセット用に渡す
-        # ─── まずDBに保存された“選んだTTL”は残す（プルダウンのselected用） ───
         d["expiration_sec"] = d.get("expiration_sec", URL_EXPIRES_SEC)
 
-        # ─── トークンから“切れる時刻(exp_ts)”を取り出し、残り秒数を計算 ───
-        import base64, time
-        token = d.get("token")
-        if token:
-            try:
-                raw     = base64.urlsafe_b64decode(token.encode())
-                _, exp_raw, _ = raw.split(b":", 2)
-                exp_ts  = int(exp_raw)
-                now_ts  = int(time.time())
-
-                # 期限切れなら即座に非共有化
-                if exp_ts != 0 and now_ts > exp_ts:
-                    table = "shared_files" if d.get("folder_id") else "files"
-                    await request.app["db"].execute(
-                        f"UPDATE {table} SET is_shared=0, token=NULL, expiration_sec=? WHERE id=?",
-                        URL_EXPIRES_SEC,
-                        d["id"],
-                    )
-                    d["is_shared"] = 0
-                    d["token"] = None
-                    token = None
-                    d["expiration"] = 0
-                    d["expiration_str"] = "期限切れ"
-                else:
-                    d["expiration"] = 0 if exp_ts == 0 else max(exp_ts - now_ts, 0)
-            except Exception:
-                # トークン異常時はTTL丸ごと残す
-                d["expiration"] = d["expiration_sec"]
+        import time
+        now_ts = int(time.time())
+        exp_ts = int(d.get("expires_at", 0) or 0)
+        if exp_ts != 0:
+            remaining = exp_ts - now_ts
+            if remaining < 0:
+                d["expiration"] = 0
+                d["expiration_str"] = "期限切れ"
+            else:
+                d["expiration"] = remaining
         else:
-            # 非共有時はゼロにしておく
             d["expiration"] = 0
 
         # ─── 残り期限のヒューマンリーダブル文字列を追加 ───
@@ -299,10 +279,22 @@ def create_app() -> web.Application:
         if not user_id:
             raise web.HTTPFound("/login")
 
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        await db.execute(
+            "UPDATE files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+        await db.execute(
+            "UPDATE shared_files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+
         # ファイル一覧取得
         # SELECT で expiration_sec も取得する
         rows = await db.fetchall(
-            "SELECT *, expiration_sec FROM files WHERE user_id = ?",
+            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ?",
             user_id
         )
         now = int(datetime.now(timezone.utc).timestamp())
@@ -374,6 +366,18 @@ def create_app() -> web.Application:
         if not member:
             raise web.HTTPForbidden(text="Not a member")
 
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        await db.execute(
+            "UPDATE files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+        await db.execute(
+            "UPDATE shared_files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+
         # フォルダ名取得
         row = await db.fetchone("SELECT name FROM shared_folders WHERE id = ?", folder_id)
         folder_name = row["name"] if row else "(不明なフォルダ)"
@@ -394,8 +398,8 @@ def create_app() -> web.Application:
                     exp = now_ts + f["expiration_sec"]
                     token = _sign_token(f["id"], exp)
                     await db.execute(
-                        "UPDATE shared_files SET token=?, expiration_sec=? WHERE id=?",
-                        token, f["expiration_sec"], f["id"]
+                        "UPDATE shared_files SET token=?, expiration_sec=?, expires_at=? WHERE id=?",
+                        token, f["expiration_sec"], exp, f["id"]
                     )
                     await db.commit()
                     f["token"] = token
@@ -428,9 +432,11 @@ def create_app() -> web.Application:
             if f["is_shared"]:
                 # token がまだ無ければ生成して DB に格納
                 if not rec["token"]:
-                    new_token = _sign_token(f["id"], now_ts + URL_EXPIRES_SEC)
+                    exp_val = now_ts + URL_EXPIRES_SEC
+                    new_token = _sign_token(f["id"], exp_val)
                     await db.execute(
-                        "UPDATE shared_files SET token=? WHERE id=?", new_token, f["id"]
+                        "UPDATE shared_files SET token=?, expires_at=? WHERE id=?",
+                        new_token, exp_val, f["id"]
                     )
                     await db.commit()
                     f["token"] = new_token
@@ -563,11 +569,23 @@ def create_app() -> web.Application:
         if not user_id:
             raise web.HTTPFound("/login")
 
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        await app["db"].execute(
+            "UPDATE files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+        await app["db"].execute(
+            "UPDATE shared_files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+
         user_row = await app["db"].fetchone("SELECT username FROM users WHERE discord_id = ?", discord_id)
         username = user_row["username"] if user_row else "Unknown"
         # expiration_sec を含めて取得するように
         rows   = await app["db"].fetchall(
-            "SELECT *, expiration_sec FROM files WHERE user_id = ?",
+            "SELECT *, expiration_sec, expires_at FROM files WHERE user_id = ?",
             user_id
         )
         now_ts = int(datetime.now(timezone.utc).timestamp())
@@ -674,13 +692,13 @@ def create_app() -> web.Application:
                 token = token.decode()
             # トークンとともに expiration_sec も保存
             await request.app["db"].execute(
-                "UPDATE files SET is_shared=1, token=?, expiration_sec=? WHERE id=?",
-                token, exp_sec, file_id
+                "UPDATE files SET is_shared=1, token=?, expiration_sec=?, expires_at=? WHERE id=?",
+                token, exp_sec, exp, file_id
             )
         else:                                      # 共有 OFF
             # 非共有に戻すときはデフォルトに
             await request.app["db"].execute(
-                "UPDATE files SET is_shared=0, token=NULL, expiration_sec=? WHERE id=?",
+                "UPDATE files SET is_shared=0, token=NULL, expiration_sec=?, expires_at=0 WHERE id=?",
                 URL_EXPIRES_SEC, file_id
             )
         await request.app["db"].commit()
@@ -807,6 +825,18 @@ def create_app() -> web.Application:
         if not user_id:
             raise web.HTTPFound("/login")
 
+        now_ts = int(datetime.now(timezone.utc).timestamp())
+        await request.app["db"].execute(
+            "UPDATE files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+        await request.app["db"].execute(
+            "UPDATE shared_files SET is_shared=0, token=NULL "
+            "WHERE is_shared=1 AND expires_at!=0 AND expires_at < ?",
+            now_ts,
+        )
+
         # 3) ファイル一覧を取得
         files = await request.app["db"].list_files(user_id)
 
@@ -877,7 +907,8 @@ def create_app() -> web.Application:
         exp_ts = int(exp_raw)
         if exp_ts != 0 and time.time() > exp_ts:
             await req.app["db"].execute(
-                "UPDATE shared_files SET is_shared=0, token=NULL WHERE id=?", fid
+                "UPDATE shared_files SET is_shared=0, token=NULL, expires_at=0 WHERE id=?",
+                fid
             )
             await req.app["db"].commit()
             raise web.HTTPNotFound()
@@ -991,13 +1022,13 @@ def create_app() -> web.Application:
                 token = token.decode()
             # 共有フォルダ内も同様に、expiration_sec を永続化
             await request.app["db"].execute(
-                "UPDATE shared_files SET is_shared=1, token=?, expiration_sec=? WHERE id=?",
-                token, exp_sec, file_id
+                "UPDATE shared_files SET is_shared=1, token=?, expiration_sec=?, expires_at=? WHERE id=?",
+                token, exp_sec, exp, file_id
             )
         else:
             # 非共有に戻すときは既定に戻す
             await request.app["db"].execute(
-                "UPDATE shared_files SET is_shared=0, token=NULL, expiration_sec=? WHERE id=?",
+                "UPDATE shared_files SET is_shared=0, token=NULL, expiration_sec=?, expires_at=0 WHERE id=?",
                 URL_EXPIRES_SEC, file_id
             )
         await db.commit()
@@ -1130,7 +1161,8 @@ def create_app() -> web.Application:
         exp_ts = int(exp_raw)
         if exp_ts != 0 and time.time() > exp_ts:
             await req.app["db"].execute(
-                "UPDATE files SET is_shared=0, token=NULL WHERE id=?", fid
+                "UPDATE files SET is_shared=0, token=NULL, expires_at=0 WHERE id=?",
+                fid
             )
             await req.app["db"].commit()
             raise web.HTTPNotFound()


### PR DESCRIPTION
## Summary
- add `expires_at` column to files and shared_files tables
- compute remaining time from `expires_at` in `_file_to_dict`
- disable expired shares when listing files
- persist `expires_at` when toggling share state

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a48154d2c832c9c7482085bf23b52