### PR TITLE
Remove duplicate rename route

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1277,7 +1277,6 @@ def create_app() -> web.Application:
     app.router.add_post("/rename/{id}", rename_file)
     app.router.add_get ("/totp",  totp_get)   # 6桁入力フォーム表示
     app.router.add_post("/totp", totp_post)   # コード検証
-    app.router.add_post("/rename/{id}", rename_file)
     app.router.add_post("/shared/rename_file/{file_id}", rename_shared_file)
     app.router.add_get("/f/{token}", public_file)
 


### PR DESCRIPTION
## Summary
- remove a duplicate route definition for `/rename/{id}` in `app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4dc197dc832ca7749561c59711b9