### PR TITLE
Update help command and add bot docs

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,35 @@
+# Discord Bot
+
+このディレクトリには Web Discord Server のボット側コードが含まれています。
+ボットはファイル共有用 Web サーバーを同時に起動し、Discord 上の操作だけで
+アップロード・共有・ダウンロードを行えるように設計されています。
+
+## 主な機能
+- サーバー参加時に自動登録し、ログイン情報と二要素認証(QRコード)をDMで送信
+- `/upload` コマンドによるファイルアップロードと `/myfiles` での一覧表示
+- 共有フォルダを作成しメンバーを招待する `/create_shared_folder`
+- 各種ファイル操作(削除・タグ付け・共有状態切替・リンク取得)
+- 管理者向けコマンド `/sync` `/admin_reset_totp` など
+- `help` コマンドで全コマンドの詳細を確認可能
+
+## コマンド一覧
+`help` コマンドでは以下のコマンドを選択して詳細説明が表示されます。
+- `ping` – レイテンシ確認
+- `myfiles` – 自分のファイル一覧をページ表示
+- `upload` – ファイルをアップロード
+- `delete` / `delete_all` – 指定ファイルまたは全ファイル削除
+- `set_tags` – ファイルにタグを設定
+- `getfile` – 保存済みファイルを再送信
+- `share` / `getlink` – 共有状態切替とダウンロードリンク取得
+- `create_shared_folder` – 共有フォルダ作成
+- `manage_shared_folder` – 共有フォルダのメンバー管理
+- `shared_files` – 参加中フォルダ内のファイル一覧
+- `delete_shared_folder` / `remove_shared_folder` – フォルダ削除・退出
+- `upload_shared` – 共有フォルダへファイルアップロード
+- `shared_delete_all` – 共有フォルダ内の全ファイル削除
+- `set_shared_tags` – 共有フォルダ内ファイルのタグ設定
+- `cleanup_shared` – 空の共有フォルダを一括削除
+- `enable_totp` – 二要素認証を有効化
+- `admin_reset_totp` – 管理者によるTOTPリセット
+
+詳細な動作や必要な環境変数については上位ディレクトリの `README.md` を参照してください。

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -70,6 +70,10 @@ class WebDiscordBot(discord.Client):
         # ③ commands.py の関数をツリーに登録
         setup_commands(self)                             # 必ず tree 生成後に呼ぶ
 
+    async def on_ready(self):
+        await self.change_presence(activity=discord.Activity(type=discord.ActivityType.listening, name="/help"))
+        log.info("Bot ready")
+
     # --------------- lifecycle ---------------
     async def setup_hook(self):
         # ❶ DB 物理接続

--- a/bot/help.py
+++ b/bot/help.py
@@ -48,6 +48,23 @@ COMMAND_SPECS: Dict[str, Dict[str, Any]] = {
             }
         ]
     },
+    "delete_all": {
+        "description": (
+            "🗑️ **delete_all** コマンドは、自分がアップロードしたすべてのファイルを一括削除します。",
+            " 容量整理や退会時に便利ですが、削除後は復元できません。"
+        ),
+        "options": []
+    },
+    "set_tags": {
+        "description": (
+            "🏷️ **set_tags** コマンドは、指定したファイルに任意のタグ文字列を設定します。",
+            " 検索や整理のために複数タグをカンマ区切りで付与できます。"
+        ),
+        "options": [
+            {"name": "file_id", "type": "String", "required": True, "description": "タグを付与するファイルID"},
+            {"name": "tags",    "type": "String", "required": True, "description": "設定するタグ（カンマ区切り）"}
+        ]
+    },
     "getfile": {
         "description": (
             "📤 **getfile** コマンドは、保存済みのファイルを再度Discordに送信します。"
@@ -60,6 +77,25 @@ COMMAND_SPECS: Dict[str, Dict[str, Any]] = {
                 "required": True,
                 "description": "再送信したいファイルのIDを指定してください。"
             }
+        ]
+    },
+    "shared_delete_all": {
+        "description": (
+            "🧺 **shared_delete_all** コマンドは、指定した共有フォルダ内のファイルをすべて削除します。",
+            " フォルダ管理者やメンバーが整理したい際に利用します。"
+        ),
+        "options": [
+            {"name": "channel", "type": "TextChannel", "required": True, "description": "対象となる共有フォルダチャンネル"}
+        ]
+    },
+    "set_shared_tags": {
+        "description": (
+            "🏷️ **set_shared_tags** コマンドは、共有フォルダ内のファイルにタグを設定します。",
+            " 権限を持つメンバーが整理しやすいようにタグ付けを行います。"
+        ),
+        "options": [
+            {"name": "file_id", "type": "String", "required": True, "description": "タグを変更するファイルID"},
+            {"name": "tags",    "type": "String", "required": True, "description": "設定するタグ（カンマ区切り）"}
         ]
     },
     "share": {


### PR DESCRIPTION
## Summary
- expand help command to describe more commands
- show `/help` in bot status when ready
- document bot usage and commands in `bot/README.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a9f4e0f04832c9ee7d34cd4330ce2