### PR TITLE
Add preview thumbnails for documents

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1089,6 +1089,11 @@ def create_app() -> web.Application:
         # Row → dict へ変換してテンプレートへ
         file_dict = dict(rec)
         file_dict["original_name"] = file_dict.get("file_name", "")   # ← 追加
+        preview_file = PREVIEW_DIR / f"{file_dict['id']}.jpg"
+        if preview_file.exists():
+            file_dict["preview_url"] = f"/previews/{preview_file.name}"
+        else:
+            file_dict["preview_url"] = f"{req.path}?preview=1"
 
         return _render(req, "public/confirm_download.html", {
             "file":    file_dict,
@@ -1395,8 +1400,14 @@ def create_app() -> web.Application:
             )
 
         # 確認ページをレンダリング
+        file_dict = dict(rec)
+        preview_file = PREVIEW_DIR / f"{file_dict['id']}.jpg"
+        if preview_file.exists():
+            file_dict["preview_url"] = f"/previews/{preview_file.name}"
+        else:
+            file_dict["preview_url"] = f"{req.path}?preview=1"
         return _render(req, "public/confirm_download.html", {
-            "file": dict(rec),   # Row → dict でテンプレートから参照しやすく
+            "file": file_dict,   # Row → dict でテンプレートから参照しやすく
             "request": req
         })
 

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -63,6 +63,16 @@
                     </button>
                     <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
                   </div>
+                {% elif f.mime.startswith('application/pdf') or f.mime.startswith('application/vnd') %}
+                  <div class="d-flex align-items-center gap-2">
+                    <button class="btn btn-outline-secondary p-0 border-0"
+                            style="width:60px;height:60px"
+                            onclick="window.open('{{ f.url }}', '_blank')">
+                      <img src="{{ f.preview_url }}"
+                           class="img-fluid rounded" style="max-height:60px;">
+                    </button>
+                    <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
+                  </div>
                 {% else %}
                 <div class="d-flex align-items-center gap-2">
                   <button class="btn btn-outline-secondary p-0 border-0"

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -65,6 +65,16 @@
                 </button>
                 <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
               </div>
+              {% elif f.mime.startswith('application/pdf') or f.mime.startswith('application/vnd') %}
+              <div class="d-flex align-items-center gap-2">
+                <button class="btn btn-outline-secondary p-0 border-0"
+                        style="width:60px;height:60px"
+                        onclick="window.open('{{ f.download_url }}', '_blank'); return false;">
+                  <img src="{{ f.preview_url }}"
+                       class="img-fluid rounded" style="max-height:60px;">
+                </button>
+                <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
+              </div>
               {% else %}
               <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-secondary p-0 border-0"

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -10,6 +10,8 @@
   <meta property="og:type" content="article">
   {% if ext in ["png", "jpg", "jpeg", "gif", "webp"] %}
   <meta property="og:image" content="{{ request.scheme }}://{{ request.host }}{{ request.path }}?dl=1">
+  {% elif ext in ["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx"] %}
+  <meta property="og:image" content="{{ request.scheme }}://{{ request.host }}{{ file.preview_url }}">
   {% endif %}
 {% endblock %}
 
@@ -23,7 +25,7 @@
       <p class="fw-bold mb-1">{{ file.original_name }}</p>
       <p class="text-muted">{{ file.size|human_size }}</p>
 
-      <!-- プレビュー（画像・HTMLのみ） -->
+      <!-- プレビュー（画像・HTML・PDF/Office） -->
 
       <div class="my-4">
         {# 画像 #}
@@ -50,6 +52,11 @@
               Your browser does not support the video tag.
             </video>
           </div>
+        {# PDF・Office 文書 #}
+        {% elif ext in ["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx"] %}
+          <img src="{{ file.preview_url }}"
+               class="img-fluid rounded shadow-sm"
+               alt="preview">
         {% endif %}
       </div>
 


### PR DESCRIPTION
## Summary
- support preview images on the download confirm page for PDF and Office files
- preview document thumbnails in file listing tables
- expose `preview_url` in download views

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685abec23e4c832c9d4d71aac9ee8a9e