### PR TITLE
Improve preview loading

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -26,6 +26,13 @@ function showFull(url, isVideoExplicit = false) {
   bsModal.show();
 }
 
+// プレビュー読み込み失敗時のフォールバック
+function previewError(img) {
+  const icon = img.parentNode?.querySelector('.fallback-icon');
+  if (icon) icon.classList.remove('d-none');
+  img.classList.add('d-none');
+}
+
 /*─────────────────────────────
     History-API / AJAX ナビゲータ
 ─────────────────────────────*/

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -46,8 +46,10 @@
                   <button class="btn btn-outline-secondary p-0 border-0"
                           style="width:60px;height:60px"
                           onclick="showFull('{{ f.url }}'); return false;">
-                    <img src="{{ f.preview_url }}"
-                          class="img-fluid rounded" style="max-height:60px;">
+                    <img src="{{ f.preview_url }}" loading="lazy"
+                          class="img-fluid rounded" style="max-height:60px;"
+                          onerror="previewError(this)">
+                    <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                   </button>
                   <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
                 </div>
@@ -56,11 +58,11 @@
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
                             onclick="showFull('{{ f.url }}', true)">
-                      <video src="{{ f.preview_url }}"
+                      <video src="{{ f.preview_url }}" preload="metadata" loading="lazy"
                               class="w-100 h-100 rounded object-fit-cover"
                               style="max-width:60px;max-height:60px;"
-                              muted autoplay loop playsinline></video>
-                    </button>
+                              muted autoplay loop playsinline onerror="previewError(this)"></video>
+                      </button>
                     <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
                   </div>
                 {% elif f.mime.startswith('application/pdf') or f.mime.startswith('application/vnd') %}
@@ -68,9 +70,11 @@
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
                             onclick="showFull('{{ f.preview_url }}'); return false;">
-                      <img src="{{ f.preview_url }}"
-                           class="img-fluid rounded" style="max-height:60px;">
-                    </button>
+                    <img src="{{ f.preview_url }}" loading="lazy"
+                         class="img-fluid rounded" style="max-height:60px;"
+                         onerror="previewError(this)">
+                    <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
+                  </button>
                     <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
                   </div>
                 {% else %}

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -47,9 +47,10 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.download_url }}'); return false;">
-                  <img src="{{ f.preview_url }}"
+                  <img src="{{ f.preview_url }}" loading="lazy"
                       class="img-fluid rounded"
-                      style="max-height:60px;">
+                      style="max-height:60px;" onerror="previewError(this)">
+                  <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                 </button>
                 <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
               </div>
@@ -58,10 +59,10 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.download_url }}', true); return false;">
-                  <video src="{{ f.preview_url }}"
+                  <video src="{{ f.preview_url }}" preload="metadata" loading="lazy"
                           class="w-100 h-100 rounded object-fit-cover"
                           style="max-width:60px;max-height:60px;"
-                          muted autoplay loop playsinline></video>
+                          muted autoplay loop playsinline onerror="previewError(this)"></video>
                 </button>
                 <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
               </div>
@@ -70,8 +71,9 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.preview_url }}'); return false;">
-                  <img src="{{ f.preview_url }}"
-                       class="img-fluid rounded" style="max-height:60px;">
+                  <img src="{{ f.preview_url }}" loading="lazy"
+                       class="img-fluid rounded" style="max-height:60px;" onerror="previewError(this)">
+                  <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                 </button>
                 <span class="file-name" data-file-id="{{ f.id }}">{{ f.original_name }}</span>
               </div>

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -30,9 +30,10 @@
       <div class="my-4">
         {# 画像 #}
         {% if ext in ["png", "jpg", "jpeg", "gif", "webp"] %}
-          <img src="{{ request.path }}?dl=1"
+          <img src="{{ request.path }}?dl=1" loading="lazy"
               class="img-fluid rounded shadow-sm"
-              alt="preview">
+              alt="preview" onerror="previewError(this)">
+          <i class="bi {{ icon_by_ext(file.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
 
         {# HTML #}
         {% elif ext in ["html", "htm"] %}
@@ -44,19 +45,19 @@
         {# ★ 動画（mp4 / webm / mov / m4v / ogg など）★ #}
         {% elif ext in ["mp4", "webm", "mov", "m4v", "ogg"] %}
           <div class="ratio ratio-16x9 border rounded shadow-sm">
-            <video src="{{ request.path }}?dl=1"
+            <video src="{{ request.path }}?dl=1" preload="metadata" loading="lazy"
                   class="w-100 h-100 rounded"
                   controls
-                  preload="metadata"
-                  playsinline>
+                  playsinline onerror="previewError(this)">
               Your browser does not support the video tag.
             </video>
           </div>
         {# PDF・Office 文書 #}
         {% elif ext in ["pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx"] %}
-          <img src="{{ file.preview_url }}"
+          <img src="{{ file.preview_url }}" loading="lazy"
                class="img-fluid rounded shadow-sm"
-               alt="preview">
+               alt="preview" onerror="previewError(this)">
+          <i class="bi {{ icon_by_ext(file.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
         {% endif %}
       </div>
 


### PR DESCRIPTION
## Summary
- add previewError helper in JS for broken previews
- lazy-load preview images and videos
- add fallback icons for PDF and Office docs

## Testing
- `bash run_tests.sh` *(fails: Could not find aiosqlite)*

------
https://chatgpt.com/codex/tasks/task_e_685bb7acf840832c8397dc6d29517c7f