### PR TITLE
Fix user lookup in DM file send

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1050,8 +1050,9 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
 
     async def user_list(req: web.Request):
         rows = await req.app["db"].list_users()
+        # Return user IDs as strings to avoid precision loss in JavaScript
         return web.json_response([
-            {"id": r["discord_id"], "name": r["username"]} for r in rows
+            {"id": str(r["discord_id"]), "name": r["username"]} for r in rows
         ])
 
     async def shared_update_tags(req: web.Request):


### PR DESCRIPTION
## Summary
- return Discord IDs as strings in `/users` API to avoid JS precision loss

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ceca0edf4832c935bb03c8b422cb2