### PR TITLE
Add dark-mode support and filter to send modal

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -1036,14 +1036,19 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
 
         path = Path(rec["path"])
         size = rec["size"]
+        sender_row = await db.fetchone("SELECT username FROM users WHERE discord_id = ?", discord_id)
+        sender_name = sender_row["username"] if sender_row else str(discord_id)
         try:
             if size <= (25 << 20):
-                await user.send(file=discord.File(path, filename=rec["original_name"]))
+                await user.send(
+                    content=f"📨 {sender_name} からのファイルです",
+                    file=discord.File(path, filename=rec["original_name"])
+                )
             else:
                 now = int(datetime.now(timezone.utc).timestamp())
                 tok = _sign_token(file_id, now + URL_EXPIRES_SEC)
                 url = f"https://{os.getenv('PUBLIC_DOMAIN','localhost:9040')}/download/{tok}"
-                await user.send(f"🔗 ダウンロードリンク: {url}")
+                await user.send(f"📨 {sender_name} からのファイルです\n🔗 ダウンロードリンク: {url}")
             return web.json_response({"status": "ok"})
         except discord.Forbidden:
             return web.json_response({"error": "forbidden"}, status=403)

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -375,3 +375,15 @@ body.dark-mode #fileSearch {
   transform: translateY(0);
   opacity: 1;
 }
+
+/* ── Send Modal Dark Mode ── */
+.dark-mode #sendModal .modal-content {
+  background-color: var(--input-bg-dark);
+  color: var(--input-text-dark);
+}
+.dark-mode #sendModal .form-select,
+.dark-mode #sendModal .form-control {
+  background-color: var(--input-bg-dark);
+  color: var(--input-text-dark);
+  border-color: var(--card-border-dark);
+}

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -133,10 +133,7 @@ async function loadUserList() {
     const res = await fetch('/users', { credentials: 'same-origin' });
     if (!res.ok) return;
     userList = await res.json();
-    const sel = document.getElementById('sendUserSelect');
-    if (sel) {
-      sel.innerHTML = userList.map(u => `<option value="${u.id}">${u.name}</option>`).join('');
-    }
+    filterUsers(document.getElementById('userFilterInput')?.value || '');
   } catch (err) {
     console.error('failed to load users', err);
   }
@@ -467,6 +464,16 @@ function filterTable(term) {
   });
 }
 
+function filterUsers(term) {
+  const sel = document.getElementById('sendUserSelect');
+  if (!sel) return;
+  const t = term.toLowerCase();
+  sel.innerHTML = userList
+    .filter(u => u.name.toLowerCase().includes(t))
+    .map(u => `<option value="${u.id}">${u.name}</option>`)
+    .join('');
+}
+
 function initProgressElems() {
   progWrap = document.getElementById("uploadProgressWrap");
   progBar  = document.getElementById("uploadProgressBar");
@@ -488,6 +495,10 @@ function rebindDynamicHandlers() {
       document.body.classList.toggle('dark-mode', sw.checked);
       localStorage.setItem('theme', sw.checked ? 'dark' : 'light');
     });
+  }
+  const userFilter = document.getElementById('userFilterInput');
+  if (userFilter) {
+    userFilter.addEventListener('input', e => filterUsers(e.target.value));
   }
   /* ───── フォルダジャンプ ───── */
   const sel = document.getElementById("folderJump");

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -75,7 +75,8 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
       <div class="modal-body">
-        <select id="sendUserSelect" class="form-select"></select>
+        <input type="text" id="userFilterInput" class="form-control mb-2" placeholder="ユーザー検索...">
+        <select id="sendUserSelect" class="form-select" size="5"></select>
         <input type="hidden" id="sendFileId" />
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Summary
- support dark-mode for send modal via CSS rules
- allow filtering user names in send form
- show sender's name when sending files

## Testing
- `pytest -q`
- `python -m py_compile web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf45f213c832ca44a50c9e336b7c4