### PR TITLE
Fix upload URL detection

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -79,9 +79,13 @@ async function reloadFileList() {
   const container = document.getElementById("fileListContainer");
   if (!container) return;
 
-  // 共有フォルダ画面なら folder_id、そうでなければ現在のパスを再取得
-  const folderId = document.querySelector('input[name="folder_id"]')?.value;
-  const url      = folderId ? `/shared/${folderId}` : window.location.pathname;
+  // data-shared 属性で URL を切り替える
+  const fldInput = document.querySelector('input[name="folder_id"]');
+  const folderId = fldInput?.value;
+  const isShared = fldInput?.dataset.shared === "1";
+  const url      = isShared && folderId
+                     ? `/shared/${folderId}`
+                     : window.location.pathname;
 
   try {
     const res  = await fetch(url, { credentials: "same-origin" });
@@ -176,9 +180,11 @@ function bindUploadArea() {
       uploadBtn.disabled = true;
       spinner.style.display = "inline-block";
 
-      // folderId／URL はここで一度だけ宣言
-      const folderId = document.querySelector('input[name="folder_id"]')?.value;
-      const reqUrl   = folderId ? "/shared/upload" : "/upload";
+      // フォルダ情報と URL を決定
+      const fldInput = document.querySelector('input[name="folder_id"]');
+      const folderId = fldInput?.value;
+      const isShared = fldInput?.dataset.shared === "1";
+      const reqUrl   = isShared ? "/shared/upload" : "/upload";
 
       // FormData を一回だけ作る
       const formData = new FormData();
@@ -213,8 +219,9 @@ function bindUploadArea() {
       if (spinner) spinner.style.display = "inline-block";
 
       const formData = new FormData(form);
-      // フォルダIDがあれば shared、なければ通常 upload
-      const isShared = formData.has("folder_id");
+      // data-shared からアップロード先を判断
+      const fldInput = form.querySelector('input[name="folder_id"]');
+      const isShared = fldInput?.dataset.shared === "1";
       const url      = isShared ? "/shared/upload" : "/upload";
 
       try {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -83,7 +83,7 @@
                 method="post"
                 enctype="multipart/form-data"
                 onsubmit="return false;">     <!-- ネイティブ送信を止める -->
-            <input type="hidden" name="folder_id" value="{{ folder_id }}">
+            <input type="hidden" name="folder_id" value="{{ folder_id }}" data-shared="0">
             <div class="row gx-3 align-items-end mb-4">
               <div class="col-sm-8">
                 <!-- multiple を付ける -->

--- a/web/templates/mobile/folder_view.html
+++ b/web/templates/mobile/folder_view.html
@@ -11,7 +11,7 @@
 
 <div id="uploadArea">
   <form id="uploadForm" class="mb-2" method="post" action="/shared/upload" enctype="multipart/form-data" onsubmit="return false;">
-    <input type="hidden" name="folder_id" value="{{ folder_id }}">
+    <input type="hidden" name="folder_id" value="{{ folder_id }}" data-shared="1">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
     <input type="file" name="file" class="form-control mb-2" required>
     <button type="button" id="uploadBtn" class="btn btn-primary w-100">アップロード

--- a/web/templates/shared/folder_view.html
+++ b/web/templates/shared/folder_view.html
@@ -69,7 +69,7 @@
             enctype="multipart/form-data"
             onsubmit="return false;"
             class="row gx-3 align-items-end mb-4">
-        <input type="hidden" name="folder_id" value="{{ folder_id }}">
+        <input type="hidden" name="folder_id" value="{{ folder_id }}" data-shared="1">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <div class="col-md-9">
           <input type="file" name="file" class="form-control" required>


### PR DESCRIPTION
## Summary
- clarify personal vs shared folder in `index.html`
- mark shared folder upload forms with `data-shared="1"`
- use `data-shared` to decide upload URL in JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0d375fe8832c8abfdfb0aae9a57b