### PR TITLE
Add subfolder deletion feature

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -366,6 +366,11 @@ class Database:
         await self.execute("DELETE FROM files WHERE folder=?", str(folder_id))
         await self.execute("DELETE FROM user_folders WHERE id=?", folder_id)
 
+    async def delete_all_subfolders(self, user_id: int, parent_id: Optional[int] = None) -> None:
+        rows = await self.list_user_folders(user_id, parent_id)
+        for r in rows:
+            await self.delete_user_folder(r["id"])
+
 
     # ファイル
     async def add_file(

--- a/web/app.py
+++ b/web/app.py
@@ -1577,6 +1577,20 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         await db.delete_user_folder(folder_id)
         raise web.HTTPFound(request.headers.get("Referer", "/"))
 
+    async def delete_subfolders(request: web.Request):
+        discord_id = request.get("user_id")
+        if not discord_id:
+            raise web.HTTPForbidden()
+        data = await request.post()
+        parent = data.get("parent_id")
+        db = request.app["db"]
+        user_id = await db.get_user_pk(discord_id)
+        if not user_id:
+            raise web.HTTPForbidden()
+        parent_id = int(parent) if parent else None
+        await db.delete_all_subfolders(user_id, parent_id)
+        raise web.HTTPFound(request.headers.get("Referer", "/"))
+
     # ─────────────── Public download confirm ───────────────
     async def public_file(req: web.Request):
         """
@@ -1662,6 +1676,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
     app.router.add_post("/shared/delete_all/{folder_id}", shared_delete_all)
     app.router.add_post("/create_folder", create_folder)
     app.router.add_post("/delete_folder/{folder_id}", delete_folder)
+    app.router.add_post("/delete_subfolders", delete_subfolders)
     app.router.add_get("/zip/{folder_id}", download_zip)
     app.router.add_post("/shared/tags/{id}", shared_update_tags)
     app.router.add_post("/shared/toggle_shared/{id}", shared_toggle)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -59,6 +59,11 @@
       </div>
       {% endfor %}
     </div>
+    <form method="post" action="/delete_subfolders" class="mt-2" onsubmit="return confirm('本当に全て削除しますか？');">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+      <input type="hidden" name="parent_id" value="{{ folder_id }}">
+      <button type="submit" class="btn btn-danger btn-sm">サブフォルダ全削除</button>
+    </form>
   </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- add `delete_all_subfolders` helper to DB
- allow users to delete all subfolders from the UI
- wire up new endpoint in `app.py`

## Testing
- `python -m py_compile bot/db.py web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685e1ae7d9e4832c9f1fd8d698706196