### PR TITLE
Implement per-IP rate limit and async tagging

### DIFF
--- a/bot/commands.py
+++ b/bot/commands.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import base64
+import asyncio
 import hashlib
 import hmac
 import os
@@ -271,7 +272,7 @@ def setup_commands(bot: discord.Client):
         path = DATA_DIR / fid
         path.write_bytes(data)
         from .auto_tag import generate_tags
-        tags = generate_tags(path)
+        tags = await asyncio.to_thread(generate_tags, path)
         await db.add_file(fid, pk, "", file.filename, str(path), len(data), hashlib.sha256(data).hexdigest(), tags)
         now = int(datetime.now(timezone.utc).timestamp())
         url = f"https://{os.getenv('PUBLIC_DOMAIN','localhost:9040')}/download/{_sign(fid, now+URL_EXPIRES_SEC)}"
@@ -645,7 +646,7 @@ def setup_commands(bot: discord.Client):
         path = DATA_DIR / fid
         path.write_bytes(data)
         from .auto_tag import generate_tags
-        tags = generate_tags(path)
+        tags = await asyncio.to_thread(generate_tags, path)
         await db.add_shared_file(fid, folder_id, file.filename, str(path), tags)
 
         # 5) Webhook で通知


### PR DESCRIPTION
## Summary
- rate limiter uses separate AsyncLimiter per remote IP
- run `generate_tags` in a thread to avoid blocking

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e1d529500832c97a212124290e3d9