### PR TITLE
Fix tags not saved on upload

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -940,7 +940,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 str(path),
                 size,
                 sha256sum,
-                "",
+                tags,
             )
             app["task_queue"].put_nowait({
                 "fid": fid,


### PR DESCRIPTION
## Summary
- save generated tags to DB when a file is uploaded so they appear without refreshing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d8f859a8832c9d0f1a16c2aaae65