### PR TITLE
Fix MIME detection for Gemini tagging

### DIFF
--- a/bot/auto_tag.py
+++ b/bot/auto_tag.py
@@ -17,8 +17,17 @@ from pptx import Presentation
 from openpyxl import load_workbook
 
 
-def generate_tags(file_path: Path) -> str:
-    """Analyze the file and return comma separated tags using Gemini."""
+def generate_tags(file_path: Path, original_name: str | None = None) -> str:
+    """Analyze the file and return comma separated tags using Gemini.
+
+    Parameters
+    ----------
+    file_path:
+        実際に保存されているファイルへのパス。
+    original_name:
+        元のファイル名。拡張子を保持していない場合に MIME 判定へ
+        利用します。
+    """
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:
         return ""
@@ -35,7 +44,7 @@ def generate_tags(file_path: Path) -> str:
     )
 
     # ファイル読み込み
-    mime, _ = mimetypes.guess_type(file_path)
+    mime, _ = mimetypes.guess_type(original_name or str(file_path))
     data = file_path.read_bytes()
 
     if not mime:

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -272,7 +272,7 @@ def setup_commands(bot: discord.Client):
         path = DATA_DIR / fid
         path.write_bytes(data)
         from .auto_tag import generate_tags
-        tags = await asyncio.to_thread(generate_tags, path)
+        tags = await asyncio.to_thread(generate_tags, path, file.filename)
         await db.add_file(fid, pk, "", file.filename, str(path), len(data), hashlib.sha256(data).hexdigest(), tags)
         now = int(datetime.now(timezone.utc).timestamp())
         url = f"https://{os.getenv('PUBLIC_DOMAIN','localhost:9040')}/download/{_sign(fid, now+URL_EXPIRES_SEC)}"
@@ -646,7 +646,7 @@ def setup_commands(bot: discord.Client):
         path = DATA_DIR / fid
         path.write_bytes(data)
         from .auto_tag import generate_tags
-        tags = await asyncio.to_thread(generate_tags, path)
+        tags = await asyncio.to_thread(generate_tags, path, file.filename)
         await db.add_shared_file(fid, folder_id, file.filename, str(path), tags)
 
         # 5) Webhook で通知

--- a/web/app.py
+++ b/web/app.py
@@ -170,7 +170,7 @@ def _generate_preview_and_tags(path: Path, fid: str, file_name: str) -> str:
         if preview_path and preview_path.exists():
             preview_path.unlink(missing_ok=True)
     from bot.auto_tag import generate_tags
-    return generate_tags(path)
+    return generate_tags(path, file_name)
 
 
 async def _task_worker(app: web.Application):
@@ -929,7 +929,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                     preview_path.unlink(missing_ok=True)
             # 自動タグ生成
             from bot.auto_tag import generate_tags
-            tags = await asyncio.to_thread(generate_tags, path)
+            tags = await asyncio.to_thread(generate_tags, path, filefield.filename)
             # DB 登録
             folder = data.get("folder") or data.get("folder_id", "")
             await app["db"].add_file(
@@ -1255,7 +1255,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 f.write(chunk)
 
         from bot.auto_tag import generate_tags
-        tags = await asyncio.to_thread(generate_tags, path)
+        tags = await asyncio.to_thread(generate_tags, path, filefield.filename)
         await db.add_shared_file(fid, folder_id, filefield.filename, str(path), tags)
         # アップロード時は自動的に共有しないようフラグをクリア
         await db.execute(


### PR DESCRIPTION
## Summary
- pass original filenames to `generate_tags` so their MIME type can be determined
- update `generate_tags` to accept optional original filename

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861da6ec9c0832cbf8b74b567677e6e