### PR TITLE
Implement background HLS conversion

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -15,11 +15,22 @@ function showFull(url, isVideoExplicit = false) {
   if (!modal || !body) return;
 
   // URL の拡張子で画像か動画か判定
-  const isVideo = isVideoExplicit || /\.(mp4|webm|ogg)$/i.test(url);
+  const isHls   = url.endsWith('.m3u8');
+  const isVideo = isVideoExplicit || /\.(mp4|webm|ogg)$/i.test(url) || isHls;
 
-  body.innerHTML = isVideo
-    ? `<video src="${url}" class="w-100" controls autoplay></video>`
-    : `<img src="${url}" class="img-fluid" />`;
+  if (isVideo) {
+    body.innerHTML = `<video id="hlsPlayer" class="w-100" controls autoplay></video>`;
+    const video = document.getElementById('hlsPlayer');
+    if (isHls && Hls.isSupported()) {
+      const hls = new Hls();
+      hls.loadSource(url);
+      hls.attachMedia(video);
+    } else {
+      video.src = url;
+    }
+  } else {
+    body.innerHTML = `<img src="${url}" class="img-fluid" />`;
+  }
 
   // Bootstrap 5 のモーダル操作
   const bsModal = bootstrap.Modal.getOrCreateInstance(modal);

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -99,6 +99,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.2/vanilla-tilt.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.4.0/mdb.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
 <script src="/static/js/main.js?v={{ static_version }}"></script>
 {% block extra_js %}{% endblock %}
 </body>

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -60,6 +60,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.2/vanilla-tilt.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.4.0/mdb.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
 <script src="/static/js/main.js?v={{ static_version }}"></script>
 {% block extra_js %}{% endblock %}
 </body>

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -58,7 +58,7 @@
                   <div class="d-flex align-items-center gap-2">
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
-                            onclick="showFull('{{ f.url }}', true)">
+                            onclick="showFull('{{ f.hls_url or f.url }}', true)">
                       <video src="{{ f.preview_url }}" preload="metadata" loading="lazy"
                               class="w-100 h-100 rounded object-fit-cover"
                               style="max-width:60px;max-height:60px;"

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -58,7 +58,7 @@
               <div class="d-flex align-items-center gap-2">
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
-                        onclick="showFull('{{ f.download_url }}', true); return false;">
+                        onclick="showFull('{{ f.hls_url or f.download_url }}', true); return false;">
                   <video src="{{ f.preview_url }}" preload="metadata" loading="lazy"
                           class="w-100 h-100 rounded object-fit-cover"
                           style="max-width:60px;max-height:60px;"


### PR DESCRIPTION
## Summary
- add HLS_DIR and serve /hls static route
- generate HLS streams via ffmpeg for uploaded videos
- expose HLS URLs in file metadata
- update viewer JS to play HLS with hls.js
- adjust templates to use the new streaming URLs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fbb0cbd0832cb0a49cd74821305a