### PR TITLE
Simplify upload section layout

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -108,6 +108,16 @@
               <button class="btn btn-outline-primary" type="submit">作成</button>
             </div>
           </form>
+          <div class="d-flex flex-column flex-sm-row gap-2 mb-3">
+            <a href="/shared" class="btn btn-outline-primary flex-fill">📁 共有フォルダを確認</a>
+            {% if gdrive_enabled %}
+              {% if gdrive_authorized %}
+              <a href="/gdrive_import" class="btn btn-outline-success flex-fill">🔄 Google Drive 取り込み</a>
+              {% else %}
+              <a href="/gdrive_auth" class="btn btn-outline-warning flex-fill">🔑 Google Drive 連携</a>
+              {% endif %}
+            {% endif %}
+          </div>
           <div class="text-center text-muted small">
             ここにファイルをドラッグ＆ドロップしてアップロード
           </div>
@@ -121,29 +131,6 @@
                 aria-valuemax="100"></div>
           </div>
   </div>
-  <!-- 共有フォルダリンクカード -->
-  <div class="card mb-4 shadow-2-strong tilt animate__animated animate__fadeInUp hover-grow"
-      data-tilt data-tilt-max="10" style="border-radius: 1rem;">
-    <div class="card mb-4 shadow-sm">
-      <div class="card-body text-center">
-        <a href="/shared" class="btn btn-outline-primary w-100">📁 共有フォルダを確認</a>
-      </div>
-    </div>
-  </div>
-  {% if gdrive_enabled %}
-  <div class="card mb-4 shadow-2-strong tilt animate__animated animate__fadeInUp hover-grow"
-      data-tilt data-tilt-max="10" style="border-radius: 1rem;">
-    <div class="card mb-4 shadow-sm">
-      <div class="card-body text-center">
-        {% if gdrive_authorized %}
-        <a href="/gdrive_import" class="btn btn-outline-success w-100">🔄 Google Drive 取り込み</a>
-        {% else %}
-        <a href="/gdrive_auth" class="btn btn-outline-warning w-100">🔑 Google Drive 連携</a>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-  {% endif %}
   <!-- ファイル一覧セクション -->
     <div id="fileListContainer">
         {% include "partials/file_table.html" %}


### PR DESCRIPTION
## Summary
- integrate shared folder and Google Drive buttons directly inside the upload card
- remove separate cards that previously held these actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864db899004832cb4d3e7fccfdeccde