### PR TITLE
Disable TOTP requirement for OAuth login

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -916,7 +916,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
 
         discord_id = int(udata["id"])
         row = await db.fetchone(
-            "SELECT totp_enabled FROM users WHERE discord_id=?",
+            "SELECT discord_id FROM users WHERE discord_id=?",
             discord_id,
         )
         if not row:
@@ -930,10 +930,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 },
             )
 
-        if row["totp_enabled"]:
-            sess["tmp_user_id"] = discord_id
-            raise web.HTTPFound("/totp")
-
+        # OAuth 経由のログインでは二要素認証を要求しない
         sess["user_id"] = discord_id
         raise web.HTTPFound("/")
 


### PR DESCRIPTION
## Summary
- skip TOTP verification when signing in via Discord OAuth

## Testing
- `python -m py_compile web/app.py`
- `python -m py_compile bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6864e6ae0348832cb6d98b9e41170a39