### PR TITLE
Add web server sequence diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Web サーバー部分は `aiohttp` を用いた非同期アプリケーショ�
 - `docs/architecture.mmd` … システム構成図
 - `docs/sequence_system.mmd` … 全体のシーケンス図
 - `docs/sequence_discord.mmd` … Discord 上のシーケンス図
+- `docs/sequence_web.mmd` … Web サーバ上のシーケンス図
 
 ## ライセンス
 このプロジェクトは MIT ライセンスです。

--- a/docs/sequence_web.mmd
+++ b/docs/sequence_web.mmd
@@ -1,0 +1,19 @@
+%%{init: {'theme': 'dark'}}%%
+%% Web サーバ上のシーケンス図
+sequenceDiagram
+    participant Browser as Browser
+    participant SW as Service Worker
+    participant Web as aiohttp Web App
+    participant DB as SQLite DB
+    participant Files as File Storage
+
+    Browser->>Web: GET /login
+    Web-->>Browser: ログインページ
+    Browser->>SW: サービスワーカー登録
+    Browser->>Web: POST /login (認証情報)
+    Web->>DB: 認証チェック
+    Web-->>Browser: セッションCookie
+    Browser->>Web: POST /upload (ファイル)
+    Web->>Files: ファイル保存
+    Web->>DB: メタデータ登録
+    Web-->>Browser: 完了レスポンス


### PR DESCRIPTION
## Summary
- add `sequence_web.mmd` to document the web server flow
- reference the new diagram in the documentation list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865fcc16498832c852594121cb4958a