### PR TITLE
Add WebSocket broadcast on upload

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -656,3 +656,23 @@ if (sendExecBtn) {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   });
 })();
+
+let ws;
+function connectWs() {
+  if (ws) return;
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${proto}://${location.host}/ws`);
+  ws.addEventListener('message', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.action === 'reload') reloadFileList();
+    } catch (err) {
+      console.error('ws message error', err);
+    }
+  });
+  ws.addEventListener('close', () => {
+    ws = null;
+    setTimeout(connectWs, 1000);
+  });
+}
+window.addEventListener('load', connectWs);


### PR DESCRIPTION
## Summary
- add WebSocket server endpoint and helper to broadcast events
- send reload event after each upload
- implement reconnecting WebSocket client in main.js

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865fe4f5a30832c82a4b45dbe4cb38a