### PR TITLE
Use mention format in webhook notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Discord OAuth でログインする際は、過去に一度でも TOTP 認証を
 ## Webhook システム
 共有フォルダでは、各チャンネルに `WDS Notify` という Webhook を紐付けており、アップロードのたびに自動通知を送信できます。
 `/create_shared_folder` でフォルダを作成すると同名の Webhook が生成され、その URL がデータベースに保存されます。
-ボットまたは Web からファイルをアップロードすると `notify_shared_upload` が呼び出され、Webhook 経由で「ユーザー名 が `<ファイル名>` をアップロードしました」と投稿されます。
+ボットまたは Web からファイルをアップロードすると `notify_shared_upload` が呼び出され、Webhook 経由で「<@ユーザーID> が `<ファイル名>` をアップロードしました」のようにメンション付きで投稿されます。
 誤って Webhook を削除した場合などは `/add_shared_webhook` コマンドで再登録が可能です。
 
 ## 起動方法

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -78,7 +78,10 @@ class WebDiscordBot(discord.Client):
         if not url:
             return
         async with aiohttp.ClientSession() as session:
-            await session.post(url, json={"content": f"📥 {user.display_name} が `{file_name}` をアップロードしました。"})
+            await session.post(
+                url,
+                json={"content": f"📥 {user.mention} が `{file_name}` をアップロードしました。"},
+            )
 
     async def on_ready(self):
         await self.change_presence(activity=discord.Activity(type=discord.ActivityType.listening, name="/help"))


### PR DESCRIPTION
## Summary
- mention users in webhook messages instead of plain names
- document that uploads now mention the user

## Testing
- `python -m py_compile bot/bot.py web/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686605c03c40832c82003c1d0e6850b1