### PR TITLE
Implement PWA manifest and improve mobile UI

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -816,6 +816,9 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
     async def service_worker(request):
         return web.FileResponse(STATIC_DIR / "service-worker.js")
 
+    async def web_manifest(request):
+        return web.FileResponse(STATIC_DIR / "manifest.json")
+
     async def offline_page(request):
         return _render(request, "offline.html", {"request": request})
 
@@ -2366,6 +2369,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
     app.router.add_get("/", index)
     app.router.add_get("/offline", offline_page)
     app.router.add_get("/service-worker.js", service_worker)
+    app.router.add_get("/manifest.json", web_manifest)
     app.router.add_get("/ws", ws_handler)
     app.router.add_get("/mobile", mobile_index)
     app.router.add_post("/upload", upload)

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -21,6 +21,11 @@ main {
   font-size: 0.9rem;
 }
 
+.navbar-brand {
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
 .table th,
 .table td {
   padding: 0.4rem;
@@ -68,6 +73,9 @@ main {
   flex-wrap: wrap;
   justify-content: center;
   gap: 0.25rem;
+}
+.file-actions .btn {
+  flex: 1 1 45%;
 }
 
 .expiration-select {

--- a/web/static/manifest.json
+++ b/web/static/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Web Discord Server",
+  "short_name": "WDS",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "lang": "ja",
+  "icons": [
+    {
+      "src": "/static/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -8,7 +8,8 @@ const OFFLINE_URLS = [
   '/static/css/style-mobile-friendly.css',
   '/static/css/style-phone.css',
   '/static/js/main.js',
-  '/static/favicon.png'
+  '/static/favicon.png',
+  '/manifest.json'
 ];
 
 self.addEventListener('install', (event) => {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -21,6 +21,8 @@
   <!-- 自作 CSS -->
   <link rel="stylesheet" href="/static/css/style.css?v={{ static_version }}">
   <link rel="icon" href="{{ static('/favicon.png') }}?v={{ static_version }}" type="image/png">
+  <link rel="manifest" href="/manifest.json?v={{ static_version }}">
+  <meta name="theme-color" content="#000000">
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -21,6 +21,8 @@
   <!-- 自作 CSS -->
   <link rel="stylesheet" href="/static/css/style.css?v={{ static_version }}">
   <link rel="icon" href="{{ static('/favicon.png') }}?v={{ static_version }}" type="image/png">
+  <link rel="manifest" href="/manifest.json?v={{ static_version }}">
+  <meta name="theme-color" content="#000000">
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>

--- a/web/templates/mobile/base_friendly.html
+++ b/web/templates/mobile/base_friendly.html
@@ -8,6 +8,8 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/static/css/style-mobile-friendly.css?v={{ static_version }}" rel="stylesheet">
   <link rel="icon" href="{{ static('/favicon.png') }}?v={{ static_version }}" type="image/png">
+  <link rel="manifest" href="/manifest.json?v={{ static_version }}">
+  <meta name="theme-color" content="#000000">
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
@@ -25,6 +27,41 @@
 </main>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/static/js/main.js?v={{ static_version }}"></script>
+<script>
+  function urlB64ToUint8Array(b64) {
+    const pad = '='.repeat((4 - b64.length % 4) % 4);
+    const base64 = (b64 + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = atob(base64);
+    return Uint8Array.from([...raw].map(c => c.charCodeAt(0)));
+  }
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+      try {
+        const reg = await navigator.serviceWorker.register('/service-worker.js?v={{ static_version }}');
+        const vapid = '{{ vapid_public_key }}';
+        if ('PushManager' in window && vapid) {
+          if (Notification.permission === 'default') {
+            await Notification.requestPermission();
+          }
+          if (Notification.permission === 'granted') {
+            const sub = await reg.pushManager.getSubscription();
+            if (!sub) {
+              try {
+                await reg.pushManager.subscribe({
+                  userVisibleOnly: true,
+                  applicationServerKey: urlB64ToUint8Array(vapid)
+                });
+              } catch (e) { console.error('push subscribe failed', e); }
+            }
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+</script>
 {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/web/templates/mobile/base_mobile.html
+++ b/web/templates/mobile/base_mobile.html
@@ -10,6 +10,8 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/static/css/style-mobile.css?v={{ static_version }}" rel="stylesheet">
   <link rel="icon" href="{{ static('/favicon.png') }}?v={{ static_version }}" type="image/png">
+  <link rel="manifest" href="/manifest.json?v={{ static_version }}">
+  <meta name="theme-color" content="#000000">
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
@@ -27,6 +29,41 @@
 </main>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/static/js/main.js?v={{ static_version }}"></script>
+<script>
+  function urlB64ToUint8Array(b64) {
+    const pad = '='.repeat((4 - b64.length % 4) % 4);
+    const base64 = (b64 + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = atob(base64);
+    return Uint8Array.from([...raw].map(c => c.charCodeAt(0)));
+  }
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+      try {
+        const reg = await navigator.serviceWorker.register('/service-worker.js?v={{ static_version }}');
+        const vapid = '{{ vapid_public_key }}';
+        if ('PushManager' in window && vapid) {
+          if (Notification.permission === 'default') {
+            await Notification.requestPermission();
+          }
+          if (Notification.permission === 'granted') {
+            const sub = await reg.pushManager.getSubscription();
+            if (!sub) {
+              try {
+                await reg.pushManager.subscribe({
+                  userVisibleOnly: true,
+                  applicationServerKey: urlB64ToUint8Array(vapid)
+                });
+              } catch (e) { console.error('push subscribe failed', e); }
+            }
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+</script>
 {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/web/templates/mobile/base_phone.html
+++ b/web/templates/mobile/base_phone.html
@@ -9,6 +9,8 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/static/css/style-phone.css?v={{ static_version }}" rel="stylesheet">
   <link rel="icon" href="{{ static('/favicon.png') }}?v={{ static_version }}" type="image/png">
+  <link rel="manifest" href="/manifest.json?v={{ static_version }}">
+  <meta name="theme-color" content="#000000">
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
@@ -67,6 +69,41 @@
 </main>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/static/js/main.js?v={{ static_version }}"></script>
+<script>
+  function urlB64ToUint8Array(b64) {
+    const pad = '='.repeat((4 - b64.length % 4) % 4);
+    const base64 = (b64 + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = atob(base64);
+    return Uint8Array.from([...raw].map(c => c.charCodeAt(0)));
+  }
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', async () => {
+      try {
+        const reg = await navigator.serviceWorker.register('/service-worker.js?v={{ static_version }}');
+        const vapid = '{{ vapid_public_key }}';
+        if ('PushManager' in window && vapid) {
+          if (Notification.permission === 'default') {
+            await Notification.requestPermission();
+          }
+          if (Notification.permission === 'granted') {
+            const sub = await reg.pushManager.getSubscription();
+            if (!sub) {
+              try {
+                await reg.pushManager.subscribe({
+                  userVisibleOnly: true,
+                  applicationServerKey: urlB64ToUint8Array(vapid)
+                });
+              } catch (e) { console.error('push subscribe failed', e); }
+            }
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+</script>
 {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `manifest.json` for PWA install
- cache manifest in service worker
- link manifest in HTML templates and set theme color
- enable service worker and push subscription in mobile bases
- tweak mobile UI styles for better layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662fcee3dc832cac7184aeab80aa2e