### PR TITLE
Fix iOS download flow

### DIFF
--- a/tests/test_confirm_download.py
+++ b/tests/test_confirm_download.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+TPL_PATH = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'public' / 'confirm_download.html'
+
+def read_template():
+    return TPL_PATH.read_text(encoding='utf-8')
+
+def test_download_button_opens_new_tab():
+    html = read_template()
+    assert 'target="_blank"' in html

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -63,7 +63,7 @@
 
       <!-- 操作ボタン -->
       <div class="mt-4 d-flex justify-content-center gap-3">
-        <a href="{{ request.path }}?dl=1"
+        <a href="{{ request.path }}?dl=1" target="_blank" rel="noopener"
            class="btn btn-primary px-4">ダウンロード</a>
         <a href="javascript:history.back()"
            class="btn btn-outline-secondary">キャンセル</a>


### PR DESCRIPTION
## Summary
- ensure mobile download uses a new browser tab
- test that the download button opens in a new tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686722c1077c832c9b7e8da038eb2541