### PR TITLE
Add download attribute for confirm page link

### DIFF
--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -64,7 +64,7 @@
       <!-- 操作ボタン -->
       <div class="mt-4 d-flex justify-content-center gap-3">
         <a href="{{ request.path }}?dl=1"
-           class="btn btn-primary px-4">ダウンロード</a>
+           class="btn btn-primary px-4" download>ダウンロード</a>
         <a href="javascript:history.back()"
            class="btn btn-outline-secondary">キャンセル</a>
       </div>


### PR DESCRIPTION
## Summary
- add `download` attribute to the confirm download link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68672753d990832cbb79d70136fc2abc