### PR TITLE
Fix PWA mobile downloads

### DIFF
--- a/tests/test_mobile_templates.py
+++ b/tests/test_mobile_templates.py
@@ -1,0 +1,22 @@
+import re
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile'
+
+
+def assert_download_attr(path: Path):
+    html = path.read_text(encoding='utf-8')
+    assert 'target="_blank"' not in html
+    assert re.search(r'<a[^>]+download', html)
+
+
+def test_file_cards_download():
+    assert_download_attr(BASE / 'partials' / 'file_cards.html')
+
+
+def test_shared_cards_download():
+    assert_download_attr(BASE / 'partials' / 'shared_folder_cards.html')
+
+
+def test_folder_view_zip_download():
+    assert_download_attr(BASE / 'folder_view.html')

--- a/web/templates/mobile/folder_view.html
+++ b/web/templates/mobile/folder_view.html
@@ -33,7 +33,7 @@
 
 <div class="mt-3 text-end">
   <a href="/shared" class="btn btn-outline-primary btn-sm me-1">戻る</a>
-  <a href="/zip/{{ folder_id }}" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener">ZIP</a>
+  <a href="/zip/{{ folder_id }}" class="btn btn-outline-secondary btn-sm me-1" download>ZIP</a>
   <a href="/" class="btn btn-outline-primary btn-sm">ホーム</a>
 </div>
 {% endblock %}

--- a/web/templates/mobile/partials/file_cards.html
+++ b/web/templates/mobile/partials/file_cards.html
@@ -13,7 +13,7 @@
       <div class="file-name small" data-file-id="{{ f.id }}">{{ f.original_name }}</div>
       <div class="text-muted small">{{ f.size|human_size }}</div>
       <div class="file-actions">
-        <a href="{{ f.url }}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
+        <a href="{{ f.url }}" class="btn btn-sm btn-outline-primary" download><i class="bi bi-download"></i> ダウンロード</a>
         <button class="btn btn-sm btn-outline-secondary send-btn" data-file-id="{{ f.id }}"><i class="bi bi-send"></i> 送信</button>
         <button class="btn btn-sm btn-outline-secondary rename-btn" data-file-id="{{ f.id }}" data-current="{{ f.original_name }}"><i class="bi bi-pencil-square"></i> 名前変更</button>
         <form method="post" action="/delete/{{ f.id }}" class="d-inline-block" onsubmit="return confirm('本当に削除しますか？');">

--- a/web/templates/mobile/partials/shared_folder_cards.html
+++ b/web/templates/mobile/partials/shared_folder_cards.html
@@ -13,7 +13,7 @@
       <div class="file-name small" data-file-id="{{ f.id }}">{{ f.original_name }}</div>
       <div class="text-muted small">{{ f.size|human_size }}</div>
       <div class="file-actions">
-        <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
+        <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary" download><i class="bi bi-download"></i> ダウンロード</a>
         {% if f.user_id == user_id %}
         <button class="btn btn-sm btn-outline-secondary rename-btn" data-file-id="{{ f.id }}" data-current="{{ f.original_name }}" data-shared="1"><i class="bi bi-pencil-square"></i> 名前変更</button>
         <form method="post" action="/shared/delete/{{ f.id }}" class="d-inline-block" onsubmit="return confirm('本当に削除しますか？');">


### PR DESCRIPTION
## Summary
- support direct file download in mobile templates
- add tests checking `download` attribute is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672b7b17cc832c8b1012534dde8486