### PR TITLE
Implement stream download via Service Worker

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -30,3 +30,9 @@ def test_handle_navigate_uses_cache_first():
     assert 'async function handleNavigate' in sw
     assert 'if (cached)' in sw
     assert 'return cached;' in sw
+
+
+def test_stream_download_support_present():
+    sw = read_sw()
+    assert 'downloadStreams' in sw
+    assert "event.data || {}" in sw

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -2,10 +2,15 @@ import re
 from pathlib import Path
 
 SW_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'service-worker.js'
+JS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
 
 
 def read_sw():
     return SW_PATH.read_text(encoding='utf-8')
+
+
+def read_js():
+    return JS_PATH.read_text(encoding='utf-8')
 
 
 def test_offline_urls_contains_cdn():
@@ -36,3 +41,9 @@ def test_stream_download_support_present():
     sw = read_sw()
     assert 'downloadStreams' in sw
     assert "event.data || {}" in sw
+
+
+def test_sw_download_handler_in_main_js():
+    js = read_js()
+    assert 'sw-dl-link' in js
+    assert 'stream-download' in js

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -47,3 +47,5 @@ def test_sw_download_handler_in_main_js():
     js = read_js()
     assert 'sw-dl-link' in js
     assert 'stream-download' in js
+    assert '_blank' in js
+    assert 'noopener' in js

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -553,6 +553,8 @@ document.addEventListener("click", async (e) => {
       const a = document.createElement('a');
       a.href = '/stream-download/' + id;
       a.download = dlLink.dataset.fileName || 'file';
+      a.target = '_blank';
+      a.rel = 'noopener';
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -533,6 +533,36 @@ window.addEventListener("pageshow", rebindDynamicHandlers);
 
 
 document.addEventListener("click", async (e) => {
+  const dlLink = e.target.closest('.sw-dl-link');
+  if (dlLink) {
+    e.preventDefault();
+    if (!navigator.serviceWorker?.controller) {
+      window.open(dlLink.href, '_blank');
+      return;
+    }
+    try {
+      const resp = await fetch(dlLink.href);
+      const stream = resp.body;
+      const id = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      navigator.serviceWorker.controller.postMessage({
+        type: 'download',
+        id: id,
+        name: dlLink.dataset.fileName || 'file',
+        stream
+      }, [stream]);
+      const a = document.createElement('a');
+      a.href = '/stream-download/' + id;
+      a.download = dlLink.dataset.fileName || 'file';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch (err) {
+      console.error(err);
+      window.open(dlLink.href, '_blank');
+    }
+    return;
+  }
+
   const sendBtn = e.target.closest(".send-btn");
   if (sendBtn) {
     const fid = sendBtn.dataset.fileId;

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -63,6 +63,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-tilt/1.7.2/vanilla-tilt.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/6.4.0/mdb.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+<script src="https://cdn.jsdelivr.net/npm/streamsaver@2.0.5/dist/streamsaver.min.js"></script>
 <script src="/static/js/main.js?v={{ static_version }}"></script>
 <script>
   function urlB64ToUint8Array(b64) {

--- a/web/templates/mobile/partials/file_cards.html
+++ b/web/templates/mobile/partials/file_cards.html
@@ -13,7 +13,7 @@
       <div class="file-name small" data-file-id="{{ f.id }}">{{ f.original_name }}</div>
       <div class="text-muted small">{{ f.size|human_size }}</div>
       <div class="file-actions">
-        <a href="{{ f.url }}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
+        <a href="{{ f.url }}" class="btn btn-sm btn-outline-primary sw-dl-link" data-file-name="{{ f.original_name }}"><i class="bi bi-download"></i> ダウンロード</a>
         <button class="btn btn-sm btn-outline-secondary send-btn" data-file-id="{{ f.id }}"><i class="bi bi-send"></i> 送信</button>
         <button class="btn btn-sm btn-outline-secondary rename-btn" data-file-id="{{ f.id }}" data-current="{{ f.original_name }}"><i class="bi bi-pencil-square"></i> 名前変更</button>
         <form method="post" action="/delete/{{ f.id }}" class="d-inline-block" onsubmit="return confirm('本当に削除しますか？');">

--- a/web/templates/mobile/partials/shared_folder_cards.html
+++ b/web/templates/mobile/partials/shared_folder_cards.html
@@ -13,7 +13,7 @@
       <div class="file-name small" data-file-id="{{ f.id }}">{{ f.original_name }}</div>
       <div class="text-muted small">{{ f.size|human_size }}</div>
       <div class="file-actions">
-        <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
+        <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary sw-dl-link" data-file-name="{{ f.original_name }}"><i class="bi bi-download"></i> ダウンロード</a>
         {% if f.user_id == user_id %}
         <button class="btn btn-sm btn-outline-secondary rename-btn" data-file-id="{{ f.id }}" data-current="{{ f.original_name }}" data-shared="1"><i class="bi bi-pencil-square"></i> 名前変更</button>
         <form method="post" action="/shared/delete/{{ f.id }}" class="d-inline-block" onsubmit="return confirm('本当に削除しますか？');">

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -90,6 +90,8 @@
             const a = document.createElement('a');
             a.href = '/stream-download/' + id;
             a.download = '{{ file.original_name }}';
+            a.target = '_blank';
+            a.rel = 'noopener';
             document.body.appendChild(a);
             a.click();
             a.remove();

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -86,7 +86,13 @@
               name: '{{ file.original_name }}',
               stream: stream
             }, [stream]);
-            location.href = '/stream-download/' + id;
+
+            const a = document.createElement('a');
+            a.href = '/stream-download/' + id;
+            a.download = '{{ file.original_name }}';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
           } catch (e) {
             console.error(e);
             document.getElementById('directDl').click();

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -63,11 +63,36 @@
 
       <!-- 操作ボタン -->
       <div class="mt-4 d-flex justify-content-center gap-3">
-        <a href="{{ request.path }}?dl=1"
+        <a href="{{ request.path }}?dl=1" id="directDl"
            class="btn btn-primary px-4">ダウンロード</a>
+        <button class="btn btn-success px-4" id="swDlBtn">SW保存</button>
         <a href="javascript:history.back()"
            class="btn btn-outline-secondary">キャンセル</a>
       </div>
+
+      <script>
+        document.getElementById('swDlBtn').addEventListener('click', async () => {
+          if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+            document.getElementById('directDl').click();
+            return;
+          }
+          try {
+            const resp = await fetch('{{ request.path }}?dl=1');
+            const stream = resp.body;
+            const id = Date.now().toString(36);
+            navigator.serviceWorker.controller.postMessage({
+              type: 'download',
+              id: id,
+              name: '{{ file.original_name }}',
+              stream: stream
+            }, [stream]);
+            location.href = '/stream-download/' + id;
+          } catch (e) {
+            console.error(e);
+            document.getElementById('directDl').click();
+          }
+        });
+      </script>
 
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add custom stream download logic in `service-worker.js`
- provide StreamSaver library on public pages
- add SW based download button on confirm page
- test for new stream download logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686733c2b06c832cac356d7c01003f62