### PR TITLE
Add prompt=consent to Discord OAuth

### DIFF
--- a/tests/test_discord_oauth.py
+++ b/tests/test_discord_oauth.py
@@ -1,0 +1,22 @@
+import sys
+import urllib.parse
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from web.utils import build_discord_oauth_url
+
+
+def test_build_discord_oauth_url_includes_prompt():
+    url = build_discord_oauth_url("123", "https://example.com/callback", "abc")
+    parsed = urllib.parse.urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "discord.com"
+    query = dict(urllib.parse.parse_qsl(parsed.query))
+    assert query.get("prompt") == "consent"
+    assert query.get("client_id") == "123"
+    assert query.get("redirect_uri") == "https://example.com/callback"
+    assert query.get("state") == "abc"
+
+

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web application package."""

--- a/web/app.py
+++ b/web/app.py
@@ -18,6 +18,8 @@ from importlib import import_module
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .utils import build_discord_oauth_url
+
 import discord
 
 from aiohttp import web
@@ -901,14 +903,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         sess["discord_state"] = state
         public_domain = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
         redirect_uri = f"https://{public_domain}/discord_callback"
-        params = {
-            "client_id": DISCORD_CLIENT_ID,
-            "redirect_uri": redirect_uri,
-            "response_type": "code",
-            "scope": "identify",
-            "state": state,
-        }
-        url = "https://discord.com/api/oauth2/authorize?" + urllib.parse.urlencode(params)
+        url = build_discord_oauth_url(DISCORD_CLIENT_ID, redirect_uri, state)
         raise web.HTTPFound(url)
 
     async def discord_callback(req: web.Request):

--- a/web/utils.py
+++ b/web/utils.py
@@ -1,0 +1,13 @@
+import urllib.parse
+
+
+def build_discord_oauth_url(client_id: str, redirect_uri: str, state: str) -> str:
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": "identify",
+        "state": state,
+        "prompt": "consent",
+    }
+    return "https://discord.com/api/oauth2/authorize?" + urllib.parse.urlencode(params)


### PR DESCRIPTION
## Summary
- include `prompt=consent` when constructing Discord OAuth URL
- factor out URL builder to `web.utils`
- add new tests for OAuth URL
- make `web` a package for easier imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673f3d7aec832c9092a64911bed0eb