### PR TITLE
Fix OAuth login redirect on mobile

### DIFF
--- a/tests/test_discord_login.py
+++ b/tests/test_discord_login.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import re
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_oauth_url_contains_disable_mobile_redirect():
+    src = APP_PATH.read_text(encoding='utf-8')
+    pattern = re.compile(r"disable_mobile_redirect\"?\s*:\s*\"true\"")
+    assert pattern.search(src)

--- a/web/app.py
+++ b/web/app.py
@@ -907,6 +907,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             "response_type": "code",
             "scope": "identify",
             "state": state,
+            "disable_mobile_redirect": "true",
         }
         url = "https://discord.com/api/oauth2/authorize?" + urllib.parse.urlencode(params)
         raise web.HTTPFound(url)


### PR DESCRIPTION
## Summary
- keep OAuth flow inside the mobile browser by adding `disable_mobile_redirect` parameter
- add regression test for OAuth URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686747022f4c832cb4605beac773a1a9