### PR TITLE
Fix Discord OAuth state management

### DIFF
--- a/tests/test_discord_state.py
+++ b/tests/test_discord_state.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_discord_states_defined():
+    content = APP_PATH.read_text(encoding='utf-8')
+    assert 'discord_states' in content


### PR DESCRIPTION
## Summary
- keep Discord OAuth state tokens in-memory instead of session cookies
- ensure callback verifies and clears this new state
- add test verifying state token code exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674cd18f68832c8ccfedf5e1add342