### PR TITLE
Add mobile subfolder listing

### DIFF
--- a/tests/test_mobile_template.py
+++ b/tests/test_mobile_template.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+TEMPLATE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'index.html'
+
+
+def test_mobile_index_has_subfolder_links():
+    text = TEMPLATE.read_text(encoding='utf-8')
+    assert '/mobile?folder=' in text

--- a/web/app.py
+++ b/web/app.py
@@ -1187,6 +1187,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             user_id,
             folder,
         )
+        parent_id = int(folder) if folder else None
+        subfolders = await app["db"].list_user_folders(user_id, parent_id)
         now_ts = int(datetime.now(timezone.utc).timestamp())
         files = []
         for r in rows:
@@ -1219,6 +1221,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 "files": files,
                 "csrf_token": token,
                 "username": username,
+                "folder_id": folder,
+                "subfolders": subfolders,
                 "gdrive_enabled": bool(GDRIVE_CREDENTIALS),
                 "gdrive_authorized": (
                     bool(await app["db"].get_gdrive_token(user_id))

--- a/web/templates/mobile/index.html
+++ b/web/templates/mobile/index.html
@@ -19,6 +19,26 @@
       <button class="btn btn-outline-primary" type="submit">作成</button>
     </div>
   </form>
+  {% if subfolders %}
+  <div class="list-group mb-3">
+    {% for f in subfolders %}
+    <div class="list-group-item d-flex justify-content-between align-items-center">
+      <a href="/mobile?folder={{ f.id }}" class="flex-grow-1 text-decoration-none">
+        <i class="bi bi-folder-fill me-2"></i>{{ f.name }}
+      </a>
+      <form method="post" action="/delete_folder/{{ f.id }}" onsubmit="return confirm('削除しますか？');">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <button type="submit" class="btn btn-sm btn-outline-danger">削除</button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  <form method="post" action="/delete_subfolders" class="mb-3" onsubmit="return confirm('本当に全て削除しますか？');">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+    <input type="hidden" name="parent_id" value="{{ folder_id }}">
+    <button class="btn btn-danger btn-sm w-100">サブフォルダ全削除</button>
+  </form>
+  {% endif %}
   </div>
 <div class="progress mt-2" id="uploadProgressWrap" style="height:4px;display:none;">
   <div id="uploadProgressBar" class="progress-bar bg-success" role="progressbar" style="width:0%" aria-valuemin="0" aria-valuemax="100"></div>


### PR DESCRIPTION
## Summary
- show user subfolders in the mobile UI
- fetch subfolders from DB in the mobile index view
- test that the mobile template includes subfolder links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8731a344832c81097af894b4e2a0