### PR TITLE
Handle cross origin fetch in service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Gemini が非対応の形式はテキストへ変換してから解析を行い�
 
 `DOWNLOAD_DOMAIN` はスマホ版ダウンロードボタンに使用するベース URL です。`https://` を含む完全な URL か、ドメイン名のみを指定できます。ドメインだけを指定した場合は `https://<DOWNLOAD_DOMAIN>` で生成されます。
 
+指定したドメインには本アプリと同じ `/download/<token>` エンドポイントが存在する必要があります。別サーバーを利用する場合は、リバースプロキシなどで `/download` パスをこのアプリへ転送してください。
+
 `COOKIE_SECRET` は次のコマンドで生成できます。
 ```bash
 python -c "import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).decode())"

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -36,4 +36,4 @@ def test_fetch_excludes_cross_origin():
     sw = read_sw()
     pattern = re.compile(r"url\.origin\s*!==\s*location\.origin")
     assert pattern.search(sw)
-    assert "event.respondWith(fetch(request))" in sw
+    assert "event.respondWith(fetch(request))" not in sw

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -30,3 +30,9 @@ def test_handle_navigate_uses_cache_first():
     assert 'async function handleNavigate' in sw
     assert 'if (cached)' in sw
     assert 'return cached;' in sw
+
+
+def test_fetch_excludes_cross_origin():
+    sw = read_sw()
+    pattern = re.compile(r"url\.origin\s*!==\s*location\.origin")
+    assert pattern.search(sw)

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -36,3 +36,4 @@ def test_fetch_excludes_cross_origin():
     sw = read_sw()
     pattern = re.compile(r"url\.origin\s*!==\s*location\.origin")
     assert pattern.search(sw)
+    assert "event.respondWith(fetch(request))" in sw

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -44,7 +44,6 @@ self.addEventListener('fetch', (event) => {
 
   // Skip cross-origin requests so the browser can handle them normally
   if (url.origin !== location.origin) {
-    event.respondWith(fetch(request));
     return;
   }
 

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -42,6 +42,11 @@ self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
+  // Skip cross-origin requests so the browser can handle them normally
+  if (url.origin !== location.origin) {
+    return;
+  }
+
   if (request.mode === 'navigate') {
     event.respondWith(handleNavigate(request));
     return;

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -44,6 +44,7 @@ self.addEventListener('fetch', (event) => {
 
   // Skip cross-origin requests so the browser can handle them normally
   if (url.origin !== location.origin) {
+    event.respondWith(fetch(request));
     return;
   }
 


### PR DESCRIPTION
## Summary
- bypass fetch handler for requests to other origins
- test for the cross origin check in service worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca5cb7df8832c97e35581f3aaf7e6