### PR TITLE
Fix websocket handshake check

### DIFF
--- a/tests/test_ws_prepare.py
+++ b/tests/test_ws_prepare.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_ws_handler_checks_upgrade():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'can_prepare(request)' in text

--- a/web/app.py
+++ b/web/app.py
@@ -840,6 +840,9 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         if not uid:
             raise web.HTTPForbidden()
         ws = web.WebSocketResponse()
+        ready = ws.can_prepare(request)
+        if not ready.ok:
+            raise web.HTTPBadRequest(text="Expected WebSocket request")
         await ws.prepare(request)
         app["websockets"].add(ws)
         try:


### PR DESCRIPTION
## Summary
- verify WebSocket request using `can_prepare` before calling `prepare`
- add regression test ensuring the handler checks upgrade

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd6163bb4832c80e4b8c328a550c4