### PR TITLE
Fix preview display for download endpoint

### DIFF
--- a/tests/test_download_preview.py
+++ b/tests/test_download_preview.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_download_allows_preview_inline():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert text.count('req.query.get("preview") == "1"') >= 2

--- a/web/app.py
+++ b/web/app.py
@@ -1642,6 +1642,12 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         mime, _ = mimetypes.guess_type(rec[filename_key])
         from urllib.parse import quote
 
+        if req.query.get("preview") == "1":
+            return web.FileResponse(
+                path,
+                headers={"Content-Type": mime or "application/octet-stream"},
+            )
+
         encoded_name = quote(rec[filename_key])
         headers = {
             "Content-Type": mime or "application/octet-stream",


### PR DESCRIPTION
## Summary
- support `preview=1` query for `/download/{token}` endpoint
- ensure JS logic/test expects two preview query checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd7ebb6d0832c846bc6e64a94b09b