### PR TITLE
Fix POST caching in service worker

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -37,3 +37,9 @@ def test_fetch_excludes_cross_origin():
     pattern = re.compile(r"url\.origin\s*!==\s*location\.origin")
     assert pattern.search(sw)
     assert "event.respondWith(fetch(request))" not in sw
+
+
+def test_network_first_skips_post_requests():
+    sw = read_sw()
+    assert "request.method !== 'GET'" in sw
+    assert 'return fetch(request);' in sw

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -88,6 +88,10 @@ async function staleWhileRevalidate(request) {
 }
 
 async function networkFirst(request) {
+  if (request.method !== 'GET') {
+    // POST などはキャッシュできないためそのままフェッチする
+    return fetch(request);
+  }
   try {
     const res = await fetch(request);
     const cache = await caches.open(CACHE_NAME);


### PR DESCRIPTION
## Summary
- prevent caching of POST requests in the service worker
- test the new behavior of networkFirst

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de12388e8832c969afa772a49c079