### PR TITLE
Enlarge phone share button

### DIFF
--- a/tests/test_share_button_size.py
+++ b/tests/test_share_button_size.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+CSS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-phone.css'
+
+
+def test_shared_toggle_has_larger_size():
+    text = CSS_PATH.read_text(encoding='utf-8')
+    assert '.shared-toggle' in text
+    assert 'padding: 0.4rem 0.6rem;' in text
+    assert 'font-size: 0.9rem;' in text

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -85,6 +85,9 @@ main {
 .shared-toggle {
   cursor: pointer;
   margin-top: 0.25rem;
+  display: inline-block;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
 }
 
 #fileListContainer .input-group {


### PR DESCRIPTION
## Summary
- make the phone UI shared-toggle badge bigger
- add a regression test verifying the new style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686df7bcb3a8832cbed994240acf1703