### PR TITLE
Fix PWA download after rename

### DIFF
--- a/tests/test_rename_reload.py
+++ b/tests/test_rename_reload.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+def test_rename_triggers_reload():
+    text = JS.read_text(encoding='utf-8')
+    assert 'btn.dataset.current = j.new_name;' in text
+    assert 'await reloadFileList();' in text

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -588,6 +588,7 @@ document.addEventListener("click", async (e) => {
     const nameEl = document.querySelector(`.file-name[data-file-id="${fileId}"]`);
     if (nameEl) nameEl.textContent = j.new_name;
     btn.dataset.current = j.new_name;
+    await reloadFileList();
   } catch (err) {
     alert("リネーム失敗: " + err);
   } finally {


### PR DESCRIPTION
## Summary
- refresh file list after renaming so download works on PWA
- test that rename triggers reload in `main.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfba1f414832c90f39137dc333a1b