### PR TITLE
Add PWA install prompt support

### DIFF
--- a/tests/test_pwa_install_button.py
+++ b/tests/test_pwa_install_button.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+template = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'base.html'
+js_path = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+
+def test_base_template_has_install_button():
+    text = template.read_text(encoding='utf-8')
+    assert 'id="installBtn"' in text
+
+
+def test_main_js_handles_beforeinstallprompt():
+    js = js_path.read_text(encoding='utf-8')
+    assert 'beforeinstallprompt' in js
+    assert 'deferredPrompt' in js

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -706,3 +706,32 @@ function connectWs() {
   });
 }
 window.addEventListener('load', connectWs);
+
+// PWA インストールフロー
+let deferredPrompt;
+window.addEventListener('beforeinstallprompt', (e) => {
+  e.preventDefault();
+  deferredPrompt = e;
+  const btn = document.getElementById('installBtn');
+  if (btn) btn.classList.remove('d-none');
+});
+
+window.addEventListener('appinstalled', () => {
+  const btn = document.getElementById('installBtn');
+  if (btn) btn.classList.add('d-none');
+  deferredPrompt = null;
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('installBtn');
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+    btn.disabled = true;
+    deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    deferredPrompt = null;
+    btn.classList.add('d-none');
+    btn.disabled = false;
+  });
+});

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -37,6 +37,11 @@
 </script>
 <!-- 画面右下に表示するトップへ戻るボタン -->
 <button id="scrollToTop" aria-label="トップへ戻る">↑</button>
+<!-- PWA インストールボタン（初期は非表示） -->
+<button id="installBtn"
+        class="btn btn-primary position-fixed bottom-0 end-0 m-3 d-none">
+  <i class="bi bi-download"></i> インストール
+</button>
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4 px-3">
   <span class="navbar-brand">WDS</span>

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -48,6 +48,11 @@
   </div>
   {% endif %}
 </nav>
+<!-- PWA インストールボタン（初期は非表示） -->
+<button id="installBtn"
+        class="btn btn-primary position-fixed bottom-0 end-0 m-3 d-none">
+  <i class="bi bi-download"></i> インストール
+</button>
 
 <main class="container mb-5">
   {% with msgs = get_flashed_messages() %}

--- a/web/templates/mobile/base_friendly.html
+++ b/web/templates/mobile/base_friendly.html
@@ -22,6 +22,11 @@
     {% endif %}
   </div>
 </nav>
+<!-- PWA インストールボタン（初期は非表示） -->
+<button id="installBtn"
+        class="btn btn-primary position-fixed bottom-0 end-0 m-3 d-none">
+  <i class="bi bi-download"></i> インストール
+</button>
 <main class="container py-4">
   {% block content %}{% endblock %}
 </main>

--- a/web/templates/mobile/base_mobile.html
+++ b/web/templates/mobile/base_mobile.html
@@ -24,6 +24,11 @@
     {% endif %}
   </div>
 </nav>
+<!-- PWA インストールボタン（初期は非表示） -->
+<button id="installBtn"
+        class="btn btn-primary position-fixed bottom-0 end-0 m-3 d-none">
+  <i class="bi bi-download"></i> インストール
+</button>
 <main class="container py-4">
   {% block content %}{% endblock %}
 </main>

--- a/web/templates/mobile/base_phone.html
+++ b/web/templates/mobile/base_phone.html
@@ -23,6 +23,11 @@
     {% endif %}
   </div>
 </nav>
+<!-- PWA インストールボタン（初期は非表示） -->
+<button id="installBtn"
+        class="btn btn-primary position-fixed bottom-0 end-0 m-3 d-none">
+  <i class="bi bi-download"></i> インストール
+</button>
 <!-- コピー完了トースト -->
 <div class="toast-container position-fixed bottom-0 end-0 p-3">
   <div id="copyToast" class="toast align-items-center text-white bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">


### PR DESCRIPTION
## Summary
- add PWA install button to base templates
- handle `beforeinstallprompt` and `appinstalled` in main.js
- add tests checking for install button and script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e00831678832c8e583bb8bf220d6e