### PR TITLE
Implement cache-busting for PWA downloads

### DIFF
--- a/tests/test_download_cache_bust.py
+++ b/tests/test_download_cache_bust.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+JS = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+
+def test_download_link_cache_bust():
+    text = JS.read_text(encoding='utf-8')
+    assert '.download-link' in text
+    assert "searchParams.set('_'" in text

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -538,6 +538,12 @@ window.addEventListener("pageshow", rebindDynamicHandlers);
 
 
 document.addEventListener("click", async (e) => {
+  const dl = e.target.closest('.download-link');
+  if (dl) {
+    const url = new URL(dl.href, location.href);
+    url.searchParams.set('_', Date.now().toString());
+    dl.href = url.toString();
+  }
   const sendBtn = e.target.closest(".send-btn");
   if (sendBtn) {
     const fid = sendBtn.dataset.fileId;

--- a/web/templates/mobile/partials/file_cards.html
+++ b/web/templates/mobile/partials/file_cards.html
@@ -13,7 +13,7 @@
       <div class="file-name small" data-file-id="{{ f.id }}">{{ f.original_name }}</div>
       <div class="text-muted small">{{ f.size|human_size }}</div>
       <div class="file-actions">
-        <a href="{{ f.url }}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
+        <a href="{{ f.url }}" class="btn btn-sm btn-outline-primary download-link" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
         <button class="btn btn-sm btn-outline-secondary send-btn" data-file-id="{{ f.id }}"><i class="bi bi-send"></i> 送信</button>
         <button class="btn btn-sm btn-outline-secondary rename-btn" data-file-id="{{ f.id }}" data-current="{{ f.original_name }}"><i class="bi bi-pencil-square"></i> 名前変更</button>
         <form method="post" action="/delete/{{ f.id }}" class="d-inline-block delete-form">

--- a/web/templates/mobile/partials/shared_folder_cards.html
+++ b/web/templates/mobile/partials/shared_folder_cards.html
@@ -13,7 +13,7 @@
       <div class="file-name small" data-file-id="{{ f.id }}">{{ f.original_name }}</div>
       <div class="text-muted small">{{ f.size|human_size }}</div>
       <div class="file-actions">
-        <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
+        <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary download-link" target="_blank" rel="noopener"><i class="bi bi-download"></i> ダウンロード</a>
         {% if f.user_id == user_id %}
         <button class="btn btn-sm btn-outline-secondary rename-btn" data-file-id="{{ f.id }}" data-current="{{ f.original_name }}" data-shared="1"><i class="bi bi-pencil-square"></i> 名前変更</button>
         <form method="post" action="/shared/delete/{{ f.id }}" class="d-inline-block delete-form">

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -91,7 +91,7 @@
             <td class="text-end" title="{{ f.size }} B">{{ f.size|human_size }}</td>
             <td class="text-center">
               <a href="{{ f.url }}"
-                  class="btn btn-sm btn-outline-primary ripple"
+                  class="btn btn-sm btn-outline-primary ripple download-link"
                   data-mdb-ripple-init
                   title="ダウンロード">
                 <i class="bi bi-download"></i>

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -91,7 +91,7 @@
             <td class="text-end" title="{{ f.size }} B">{{ f.size|human_size }}</td>
 
             <td class="text-center">
-              <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary ripple" data-mdb-ripple-init title="ダウンロード">
+              <a href="{{ f.download_url }}" class="btn btn-sm btn-outline-primary ripple download-link" data-mdb-ripple-init title="ダウンロード">
                 <i class="bi bi-download"></i>
               </a>
             </td>


### PR DESCRIPTION
## Summary
- mark file download links with `download-link` class
- add JS handler to append timestamp query parameter to download links
- ensure JS is tested for cache busting behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e08bef0f8832c92853c5df801504a