### PR TITLE
Fix PWA download navigation

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -43,3 +43,8 @@ def test_network_first_skips_post_requests():
     sw = read_sw()
     assert "request.method !== 'GET'" in sw
     assert 'return fetch(request);' in sw
+
+
+def test_fetch_skips_download_paths():
+    sw = read_sw()
+    assert "url.pathname.startsWith('/download/')" in sw

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -47,6 +47,10 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  if (url.pathname.startsWith('/download/')) {
+    return;
+  }
+
   if (request.mode === 'navigate') {
     event.respondWith(handleNavigate(request));
     return;


### PR DESCRIPTION
## Summary
- skip `/download/` requests in service worker
- test service worker for download skip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e03e89490832c919c876f57d0700d