### PR TITLE
Add bypass caching for download paths

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -34,12 +34,23 @@ def test_handle_navigate_uses_cache_first():
 
 def test_fetch_excludes_cross_origin():
     sw = read_sw()
-    pattern = re.compile(r"url\.origin\s*!==\s*location\.origin")
+    pattern = re.compile(
+        r"url\.origin\s*!==\s*location\.origin\)\s*{\s*return;",
+        re.S,
+    )
     assert pattern.search(sw)
-    assert "event.respondWith(fetch(request))" not in sw
 
 
 def test_network_first_skips_post_requests():
     sw = read_sw()
     assert "request.method !== 'GET'" in sw
     assert 'return fetch(request);' in sw
+
+
+def test_download_requests_not_cached():
+    sw = read_sw()
+    pattern = re.compile(
+        r"if\s*\(\s*url\.pathname\.startsWith\('/download'\)\s*\|\|\s*url\.pathname\.startsWith\('/shared/download'\)\s*\)\s*{\s*event\.respondWith\(fetch\(request\)\);\s*return;",
+        re.S,
+    )
+    assert pattern.search(sw)

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -57,6 +57,14 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  if (
+    url.pathname.startsWith('/download') ||
+    url.pathname.startsWith('/shared/download')
+  ) {
+    event.respondWith(fetch(request));
+    return;
+  }
+
   // それ以外の API や部分 HTML などは新しい内容を優先
   event.respondWith(networkFirst(request));
 });


### PR DESCRIPTION
## Summary
- avoid caching `/download` and `/shared/download` requests in the service worker
- update service worker tests
- add regex test ensuring download paths are not cached

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1098e944832cbe04cf52914286d0