### PR TITLE
Enable exe file icon

### DIFF
--- a/tests/test_exe_icon.py
+++ b/tests/test_exe_icon.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+def test_icon_map_contains_exe():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert '"exe": "bi-file-earmark-binary"' in text

--- a/web/app.py
+++ b/web/app.py
@@ -429,6 +429,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         "java": "bi-file-earmark-code",
         "c": "bi-file-earmark-code",
         "cpp": "bi-file-earmark-code",
+        # 実行ファイル
+        "exe": "bi-file-earmark-binary",
         # 音楽
         "mp3": "bi-file-earmark-music",
         "wav": "bi-file-earmark-music",


### PR DESCRIPTION
## Summary
- add icon mapping for .exe files
- check for exe icon mapping in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e135b2b70832c8d9bb2717bba4016