### PR TITLE
Fix TOTP CSRF caching

### DIFF
--- a/tests/test_totp_cache_control.py
+++ b/tests/test_totp_cache_control.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_totp_get_sets_no_store():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'Cache-Control"] = "no-store"' in text

--- a/web/app.py
+++ b/web/app.py
@@ -995,7 +995,9 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         if "tmp_user_id" not in sess:  # 直アクセス対策
             raise web.HTTPFound("/login")
         # CSRF トークンをテンプレに渡す
-        return _render(req, "totp.html", {"csrf_token": await issue_csrf(req)})
+        resp = _render(req, "totp.html", {"csrf_token": await issue_csrf(req)})
+        resp.headers["Cache-Control"] = "no-store"
+        return resp
 
     # ── POST: 検証 ────────────────────────────
     async def totp_post(req):
@@ -1017,11 +1019,13 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             )
             raise web.HTTPFound("/")
 
-        return _render(
+        resp = _render(
             req,
             "totp.html",
             {"error": "コードが違います", "csrf_token": await issue_csrf(req)},
         )
+        resp.headers["Cache-Control"] = "no-store"
+        return resp
 
     async def logout(req):
         session = await aiohttp_session.get_session(req)


### PR DESCRIPTION
## Summary
- prevent caching on `/totp` page by sending `Cache-Control: no-store`
- test for presence of cache control header

## Testing
- `pytest -q`
- `pytest -q tests/test_totp_cache_control.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_686e1686b2c0832c9b73c01dca494ee5