### PR TITLE
Fix service worker POST navigation cache error

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -32,6 +32,18 @@ def test_handle_navigate_uses_cache_first():
     assert 'return cached;' in sw
 
 
+def test_handle_navigate_skips_post_requests():
+    sw = read_sw()
+    pattern = re.compile(
+        r"async function handleNavigate\(request\)\s*{\s*"
+        r"if \(request.method !== 'GET'\) \{\s*"
+        r"// POST ナビゲーションはキャッシュしない\s*"
+        r"return fetch\(request\);",
+        re.S,
+    )
+    assert pattern.search(sw)
+
+
 def test_fetch_excludes_cross_origin():
     sw = read_sw()
     pattern = re.compile(

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -70,6 +70,10 @@ self.addEventListener('fetch', (event) => {
 });
 
 async function handleNavigate(request) {
+  if (request.method !== 'GET') {
+    // POST ナビゲーションはキャッシュしない
+    return fetch(request);
+  }
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(request);
   if (cached) {


### PR DESCRIPTION
## Summary
- avoid caching POST navigations in the service worker
- test that POST navigations are skipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1b4cdce4832ca02a10a1ab789ab4