### PR TITLE
Fix DM file send limit

### DIFF
--- a/bot/commands.py
+++ b/bot/commands.py
@@ -53,6 +53,7 @@ def make_otp_link(uri: str) -> str:
 
 # Discord 添付アップロード制限 (Nitroプラン別)
 SIZE_LIMIT = {2: 500 << 20, 1: 100 << 20, 0: 25 << 20}
+DM_UPLOAD_LIMIT = int(os.getenv("DISCORD_DM_UPLOAD_LIMIT", 8 << 20))
 
 # 連続送信抑制インターバル (秒)
 SEND_INTERVAL_SEC = int(os.getenv("SEND_INTERVAL_SEC", 60))
@@ -390,7 +391,7 @@ def setup_commands(bot: discord.Client):
         path = Path(rec["path"])
         size = rec["size"]
         try:
-            if size <= (25 << 20):
+            if size <= DM_UPLOAD_LIMIT:
                 await user.send(file=discord.File(path, filename=rec["original_name"]))
             else:
                 now = int(datetime.now(timezone.utc).timestamp())

--- a/tests/test_dm_upload_limit.py
+++ b/tests/test_dm_upload_limit.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_dm_upload_limit_constant():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'DM_UPLOAD_LIMIT' in text
+    assert 'size <= DM_UPLOAD_LIMIT' in text

--- a/web/app.py
+++ b/web/app.py
@@ -74,6 +74,7 @@ GDRIVE_CREDENTIALS = os.getenv("GDRIVE_CREDENTIALS")
 VAPID_PUBLIC_KEY = os.getenv("VAPID_PUBLIC_KEY", "").strip()
 DISCORD_CLIENT_ID = os.getenv("DISCORD_CLIENT_ID")
 DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
+DM_UPLOAD_LIMIT = int(os.getenv("DISCORD_DM_UPLOAD_LIMIT", 8 << 20))
 
 # ─────────────── Helpers ───────────────
 MOBILE_TEMPLATES = {
@@ -1856,7 +1857,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         )
         sender_name = sender_row["username"] if sender_row else str(discord_id)
         try:
-            if size <= (25 << 20):
+            if size <= DM_UPLOAD_LIMIT:
                 await user.send(
                     content=f"📨 {sender_name} からのファイルです",
                     file=discord.File(path, filename=rec["original_name"]),


### PR DESCRIPTION
## Summary
- add `DM_UPLOAD_LIMIT` constant in web/app
- use the constant when sending DMs from the web app
- add same constant to bot commands
- add regression test checking the constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2248753c832cb25a5eff4f0f30c7