### PR TITLE
Remove cancel button from download page

### DIFF
--- a/tests/test_confirm_preview.py
+++ b/tests/test_confirm_preview.py
@@ -5,3 +5,8 @@ HTML = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'public' / 'c
 def test_confirm_preview_param():
     text = HTML.read_text(encoding='utf-8')
     assert text.count('?preview=1') >= 3
+
+
+def test_cancel_button_removed():
+    text = HTML.read_text(encoding='utf-8')
+    assert 'キャンセル' not in text

--- a/web/templates/public/confirm_download.html
+++ b/web/templates/public/confirm_download.html
@@ -65,8 +65,6 @@
       <div class="mt-4 d-flex justify-content-center gap-3">
         <a href="{{ request.path }}?dl=1"
            class="btn btn-primary px-4">ダウンロード</a>
-        <a href="javascript:history.back()"
-           class="btn btn-outline-secondary">キャンセル</a>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
- remove cancel button from the shared download confirmation page
- ensure tests fail if the cancel button comes back

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e22c95074832c8cef437b8a1234d4