### PR TITLE
Add timeouts to external HTTP requests

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -40,6 +40,7 @@ PUBLIC_DOMAIN = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
 WEB_PORT      = int(os.getenv("PORT", 9040))
 OWNER_ID      = int(os.getenv("BOT_OWNER_ID", "0")) or None   # 製作者の ID
 DEV_GUILD_ID = int(os.getenv("BOT_GUILD_ID", "0")) or None   # ← ここで定数化
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=15)
 
 # ───────────────────────────────────────
 # 2. log
@@ -77,7 +78,7 @@ class WebDiscordBot(discord.Client):
         url = rec.get("webhook_url") if rec else None
         if not url:
             return
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
             await session.post(
                 url,
                 json={"content": f"📥 {user.mention} が `{file_name}` をアップロードしました。"},

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -40,7 +40,7 @@ PUBLIC_DOMAIN = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
 WEB_PORT      = int(os.getenv("PORT", 9040))
 OWNER_ID      = int(os.getenv("BOT_OWNER_ID", "0")) or None   # 製作者の ID
 DEV_GUILD_ID = int(os.getenv("BOT_GUILD_ID", "0")) or None   # ← ここで定数化
-HTTP_TIMEOUT = aiohttp.ClientTimeout(total=15)
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=60)
 
 # ───────────────────────────────────────
 # 2. log

--- a/tests/test_client_timeout.py
+++ b/tests/test_client_timeout.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+BOT_PATH = Path(__file__).resolve().parents[1] / 'bot' / 'bot.py'
+
+
+def test_http_timeout_defined():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'HTTP_TIMEOUT' in text
+    assert 'ClientTimeout' in text
+    assert 'timeout=HTTP_TIMEOUT' in text
+
+
+def test_bot_http_timeout():
+    text = BOT_PATH.read_text(encoding='utf-8')
+    assert 'HTTP_TIMEOUT' in text
+    assert 'timeout=HTTP_TIMEOUT' in text

--- a/web/app.py
+++ b/web/app.py
@@ -78,7 +78,7 @@ DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
 # HTTPS 強制リダイレクトの有無
 FORCE_HTTPS = os.getenv("FORCE_HTTPS", "0").lower() in {"1", "true", "yes"}
 DM_UPLOAD_LIMIT = int(os.getenv("DISCORD_DM_UPLOAD_LIMIT", 8 << 20))
-HTTP_TIMEOUT = aiohttp.ClientTimeout(total=15)
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=60)
 
 # ─────────────── Helpers ───────────────
 MOBILE_TEMPLATES = {

--- a/web/app.py
+++ b/web/app.py
@@ -78,6 +78,7 @@ DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
 # HTTPS 強制リダイレクトの有無
 FORCE_HTTPS = os.getenv("FORCE_HTTPS", "0").lower() in {"1", "true", "yes"}
 DM_UPLOAD_LIMIT = int(os.getenv("DISCORD_DM_UPLOAD_LIMIT", 8 << 20))
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=15)
 
 # ─────────────── Helpers ───────────────
 MOBILE_TEMPLATES = {
@@ -166,7 +167,7 @@ async def _send_shared_webhook(db: Database, folder_id: int, message: str) -> No
     url = rec["webhook_url"] if rec else None
     if not url:
         return
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
         await session.post(url, json={"content": message})
 
 
@@ -967,7 +968,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             "redirect_uri": redirect_uri,
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(timeout=HTTP_TIMEOUT) as session:
             async with session.post("https://discord.com/api/oauth2/token", data=data, headers=headers) as resp:
                 if resp.status != 200:
                     log.error("OAuth token error: %s", await resp.text())


### PR DESCRIPTION
## Summary
- add `HTTP_TIMEOUT` constant and apply it to aiohttp sessions
- enforce same timeout in bot notifications
- test that timeout configuration exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e62fa4ba8832cba51b847ebc85522