### PR TITLE
Fix POST caching in handleNavigate

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -47,6 +47,12 @@ def test_network_first_skips_post_requests():
     assert 'return fetch(request);' in sw
 
 
+def test_handle_navigate_skips_post_requests():
+    sw = read_sw()
+    assert "request.method === 'POST'" in sw
+    assert 'return fetch(request);' in sw
+
+
 def test_download_requests_not_cached():
     sw = read_sw()
     pattern = re.compile(

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -70,6 +70,9 @@ self.addEventListener('fetch', (event) => {
 });
 
 async function handleNavigate(request) {
+  if (request.method === 'POST') {
+    return fetch(request);
+  }
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(request);
   if (cached) {


### PR DESCRIPTION
## Summary
- update service worker to skip caching for POST navigations
- ensure POST is excluded with a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6ecf54f0832cac534c3c9c93a9a9