### PR TITLE
Fix WebSocket transport check

### DIFF
--- a/tests/test_ws_prepare.py
+++ b/tests/test_ws_prepare.py
@@ -6,3 +6,8 @@ APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 def test_ws_handler_checks_upgrade():
     text = APP_PATH.read_text(encoding='utf-8')
     assert 'can_prepare(request)' in text
+
+
+def test_ws_handler_checks_transport():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'request.transport is None' in text

--- a/web/app.py
+++ b/web/app.py
@@ -866,7 +866,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             raise web.HTTPForbidden()
         ws = web.WebSocketResponse()
         ready = ws.can_prepare(request)
-        if not ready.ok:
+        if not ready.ok or request.transport is None:
             raise web.HTTPBadRequest(text="Expected WebSocket request")
         await ws.prepare(request)
         app["websockets"].add(ws)


### PR DESCRIPTION
## Summary
- guard websocket preparation by verifying the request transport
- test ws_handler checks request transport is None

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6d67fa78832c9e3402e2d6b87eb7