### PR TITLE
Fix websocket connection on login page

### DIFF
--- a/tests/test_logged_in_attr.py
+++ b/tests/test_logged_in_attr.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+TEMPLATES = [
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'base.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'base_public.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_phone.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_mobile.html',
+    Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_friendly.html',
+]
+
+
+def test_body_has_logged_in_attr():
+    for tpl in TEMPLATES:
+        text = tpl.read_text(encoding='utf-8')
+        assert 'data-logged-in="{{ 1 if user_id else 0 }}"' in text

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -690,6 +690,7 @@ if (sendExecBtn) {
 let ws;
 function connectWs() {
   if (ws) return;
+  if (document.body.dataset.loggedIn !== '1') return;
   const proto = location.protocol === 'https:' ? 'wss' : 'ws';
   ws = new WebSocket(`${proto}://${location.host}/ws`);
   ws.addEventListener('message', (e) => {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -26,7 +26,7 @@
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
-<body>
+<body data-logged-in="{{ 1 if user_id else 0 }}">
 <!-- FOUC 対策：CSS 読み込み前に body.dark-mode を付与 -->
 <script>
     const theme       = localStorage.getItem('theme');

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -26,7 +26,7 @@
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
-<body>
+<body data-logged-in="{{ 1 if user_id else 0 }}">
 <!-- FOUC 対策：CSS 読み込み前に body.dark-mode を付与 -->
 <script>
     const theme       = localStorage.getItem('theme');

--- a/web/templates/mobile/base_friendly.html
+++ b/web/templates/mobile/base_friendly.html
@@ -13,7 +13,7 @@
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
-<body>
+<body data-logged-in="{{ 1 if user_id else 0 }}">
 <nav class="navbar navbar-dark bg-primary py-2">
   <div class="container-fluid justify-content-between">
     <span class="navbar-brand mb-0 h1">WDS</span>

--- a/web/templates/mobile/base_mobile.html
+++ b/web/templates/mobile/base_mobile.html
@@ -15,7 +15,7 @@
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
-<body>
+<body data-logged-in="{{ 1 if user_id else 0 }}">
 <nav class="navbar navbar-dark bg-dark">
   <div class="container-fluid">
     <span class="navbar-brand">WDS</span>

--- a/web/templates/mobile/base_phone.html
+++ b/web/templates/mobile/base_phone.html
@@ -14,7 +14,7 @@
   <meta name="csrf-token" content="{{ csrf_token }}">
   {% block extra_meta %}{% endblock %}
 </head>
-<body>
+<body data-logged-in="{{ 1 if user_id else 0 }}">
 <nav class="navbar navbar-dark bg-dark">
   <div class="container-fluid">
     <span class="navbar-brand">WDS</span>


### PR DESCRIPTION
## Summary
- stop connecting WebSocket when not logged in
- embed `data-logged-in` flag in base templates
- test presence of the flag in templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6f18e704832caedb54c908fed034