### PR TITLE
Add disable_mobile_redirect to Discord OAuth URL

### DIFF
--- a/tests/test_discord_login_disable_mobile.py
+++ b/tests/test_discord_login_disable_mobile.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_disable_mobile_redirect_param():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'disable_mobile_redirect' in text

--- a/web/app.py
+++ b/web/app.py
@@ -946,6 +946,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             "response_type": "code",
             "scope": "identify",
             "state": state,
+            "disable_mobile_redirect": "true",
         }
         url = "https://discord.com/api/oauth2/authorize?" + urllib.parse.urlencode(params)
         raise web.HTTPFound(url)


### PR DESCRIPTION
## Summary
- prevent automatic Discord app opening when logging in on mobile
- add regression test for the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6f6ba8c8832c92e9432f84ae9b5d