### PR TITLE
Fix TOTP page caching

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -60,3 +60,9 @@ def test_download_requests_not_cached():
         re.S,
     )
     assert pattern.search(sw)
+
+
+def test_no_store_header_prevents_caching():
+    sw = read_sw()
+    pattern = re.compile(r"headers\.get\('Cache-Control'\) !== 'no-store'")
+    assert len(pattern.findall(sw)) >= 2

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -76,7 +76,11 @@ async function handleNavigate(request) {
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(request);
   if (cached) {
-    fetch(request).then(res => cache.put(request, res.clone())).catch(() => {});
+    fetch(request).then(res => {
+      if (res.headers.get('Cache-Control') !== 'no-store') {
+        cache.put(request, res.clone());
+      }
+    }).catch(() => {});
     return cached;
   }
   try {
@@ -84,7 +88,9 @@ async function handleNavigate(request) {
     if (res.type === 'opaqueredirect') {
       return Response.redirect(res.url, 302);
     }
-    cache.put(request, res.clone());
+    if (res.headers.get('Cache-Control') !== 'no-store') {
+      cache.put(request, res.clone());
+    }
     return res;
   } catch (_) {
     return caches.match(OFFLINE_PAGE);
@@ -114,8 +120,10 @@ async function networkFirst(request) {
     if (res.type === 'opaqueredirect') {
       return Response.redirect(res.url, 302);
     }
-    const cache = await caches.open(CACHE_NAME);
-    cache.put(request, res.clone());
+    if (res.headers.get('Cache-Control') !== 'no-store') {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, res.clone());
+    }
     return res;
   } catch (_) {
     return caches.match(request);


### PR DESCRIPTION
## Summary
- skip caching pages with `Cache-Control: no-store` in the service worker
- test that the service worker checks for this header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e75acc818832cb67e6c8a8d0251b1