### PR TITLE
Add invalid session cookie logging

### DIFF
--- a/tests/test_invalid_session_cookie_logging.py
+++ b/tests/test_invalid_session_cookie_logging.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+def test_invalid_session_cookie_logging():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'wdsid cookie present but session could not be restored' in text
+    assert 'log.warning' in text

--- a/web/app.py
+++ b/web/app.py
@@ -340,6 +340,8 @@ async def csrf_protect_mw(request: web.Request, handler):
 @web.middleware
 async def auth_mw(request: web.Request, handler):
     sess = await aiohttp_session.get_session(request)
+    if request.cookies.get("wdsid") and sess.new:
+        log.warning("wdsid cookie present but session could not be restored")
     request["user_id"] = sess.get("user_id")
     return await handler(request)
 


### PR DESCRIPTION
## Summary
- log warning when `wdsid` cookie is present but cannot be restored
- test that the invalid cookie message is included in the code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2e56e19c832cab62672e079f4183