### PR TITLE
Fix session handling

### DIFF
--- a/tests/test_only_discord_login_invalidates.py
+++ b/tests/test_only_discord_login_invalidates.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_only_discord_login_invalidates():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert text.count('sess.invalidate()') == 1
+    assert 'session.invalidate()' not in text

--- a/web/app.py
+++ b/web/app.py
@@ -966,7 +966,9 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             return resp
 
         sess = await get_session(req)
-        sess.invalidate()
+        # invalidate() は使わず、必要なキーのみ更新する
+        sess.pop("user_id", None)
+        sess.pop("tmp_user_id", None)
 
         if row["totp_enabled"]:
             sess["tmp_user_id"] = row["discord_id"]
@@ -1134,7 +1136,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
 
     async def logout(req):
         session = await aiohttp_session.get_session(req)
-        session.invalidate()
+        # invalidate() は使わずセッションの内容だけをクリア
+        session.clear()
         raise web.HTTPFound("/login")
 
     async def gdrive_auth(req: web.Request):


### PR DESCRIPTION
## Summary
- avoid calling `invalidate()` during login and logout
- clear session directly on logout
- verify only `/discord_login` invalidates the session

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f3953b070832cb0ac483610948a42