### PR TITLE
Simplify auth session handling

### DIFF
--- a/tests/test_discord_state.py
+++ b/tests/test_discord_state.py
@@ -3,6 +3,6 @@ from pathlib import Path
 APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 
 
-def test_discord_states_defined():
+def test_oauth_state_defined():
     content = APP_PATH.read_text(encoding='utf-8')
-    assert 'discord_states' in content
+    assert 'oauth_state' in content

--- a/tests/test_discord_state_session.py
+++ b/tests/test_discord_state_session.py
@@ -5,9 +5,9 @@ APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
 
 def test_state_saved_in_session():
     text = APP_PATH.read_text(encoding='utf-8')
-    assert 'sess["discord_state"] = state' in text
+    assert 'auth["oauth_state"] = state' in text
 
 
 def test_state_popped_in_callback():
     text = APP_PATH.read_text(encoding='utf-8')
-    assert 'sess.pop("discord_state"' in text
+    assert 'auth.pop("oauth_state"' in text


### PR DESCRIPTION
## Summary
- keep session auth info in a single `auth` dict
- drop global `discord_states` set and update OAuth flow
- adjust Google Drive OAuth session keys
- update tests for new state names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68705c242910832cb3513f7b6a28e866