### PR TITLE
Implement QR-based login for PC

### DIFF
--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -20,3 +20,8 @@ def test_discord_button_removed():
     mobile_html = MOBILE_TEMPLATE.read_text(encoding='utf-8')
     assert '/discord_login' not in pc_html
     assert '/discord_login' in mobile_html
+
+
+def test_qr_done_rendered_on_mobile_flow():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert text.count('qr_done.html') >= 4

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+LOGIN_TEMPLATE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'login.html'
+MOBILE_TEMPLATE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'login.html'
+
+
+def test_qr_tokens_defined():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'qr_tokens' in text
+
+
+def test_login_template_has_qr_image():
+    html = LOGIN_TEMPLATE.read_text(encoding='utf-8')
+    assert '/qr_image/' in html
+
+
+def test_discord_button_removed():
+    pc_html = LOGIN_TEMPLATE.read_text(encoding='utf-8')
+    mobile_html = MOBILE_TEMPLATE.read_text(encoding='utf-8')
+    assert '/discord_login' not in pc_html
+    assert '/discord_login' not in mobile_html

--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -19,4 +19,4 @@ def test_discord_button_removed():
     pc_html = LOGIN_TEMPLATE.read_text(encoding='utf-8')
     mobile_html = MOBILE_TEMPLATE.read_text(encoding='utf-8')
     assert '/discord_login' not in pc_html
-    assert '/discord_login' not in mobile_html
+    assert '/discord_login' in mobile_html

--- a/web/app.py
+++ b/web/app.py
@@ -2507,6 +2507,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
     app.router.add_get("/health", health)
     app.router.add_get("/login", login_get)
     app.router.add_post("/login", login_post)
+    app.router.add_get("/discord_login", discord_login)
+    app.router.add_get("/discord_callback", discord_callback)
     app.router.add_get("/qr_image/{token}", qr_image)
     app.router.add_get("/qr_login/{token}", qr_login)
     app.router.add_get("/qr_poll/{token}", qr_poll)

--- a/web/app.py
+++ b/web/app.py
@@ -889,7 +889,11 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         return web.json_response({"status": "ok"})
 
     async def login_get(req):
+        prev = await aiohttp_session.get_session(req)
+        pending = prev.pop("pending_qr", None)
         sess = await new_session(req)
+        if pending:
+            sess["pending_qr"] = pending
         csrf = await issue_csrf(req)
         qr_token = secrets.token_urlsafe(16)
         sess["qr_token"] = qr_token
@@ -932,8 +936,11 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 },
             )
 
+        old_sess = await aiohttp_session.get_session(req)
+        qr_pending = old_sess.pop("pending_qr", None)
         sess = await new_session(req)
-        qr_pending = sess.pop("pending_qr", None)
+        if qr_pending:
+            sess["pending_qr"] = qr_pending
 
         if row["totp_enabled"]:
             sess["tmp_user_id"] = row["discord_id"]
@@ -941,19 +948,24 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 sess["pending_qr"] = qr_pending
             raise web.HTTPFound("/totp")
 
-        sess["user_id"] = row["discord_id"]
         if qr_pending:
             info = req.app["qr_tokens"].get(qr_pending)
             if info and info["expires"] > time.time():
                 info["user_id"] = row["discord_id"]
+            return _render(req, "qr_done.html", {"request": req})
+
+        sess["user_id"] = row["discord_id"]
         raise web.HTTPFound("/")
 
     async def discord_login(req: web.Request):
         if not (DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET):
             raise web.HTTPFound("/login")
         state = secrets.token_urlsafe(16)
-        # 新しいセッションを開始し、以前の tmp_user_id を残さない
-        await new_session(req)
+        prev = await aiohttp_session.get_session(req)
+        pending = prev.pop("pending_qr", None)
+        sess = await new_session(req)
+        if pending:
+            sess["pending_qr"] = pending
         req.app["discord_states"].add(state)
         public_domain = os.getenv("PUBLIC_DOMAIN", "localhost:9040")
         redirect_uri = f"https://{public_domain}/discord_callback"
@@ -971,6 +983,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         if not (DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET):
             raise web.HTTPFound("/login")
         sess = await aiohttp_session.get_session(req)
+        qr_pending = sess.pop("pending_qr", None)
         state = req.query.get("state")
         if not state or state not in req.app["discord_states"]:
             return web.Response(text="invalid state", status=400)
@@ -1021,7 +1034,15 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
 
         if row["totp_enabled"] and not row["totp_verified"]:
             sess["tmp_user_id"] = discord_id
+            if qr_pending:
+                sess["pending_qr"] = qr_pending
             raise web.HTTPFound("/totp")
+
+        if qr_pending:
+            info = req.app["qr_tokens"].get(qr_pending)
+            if info and info["expires"] > time.time():
+                info["user_id"] = discord_id
+            return _render(req, "qr_done.html", {"request": req})
 
         sess["user_id"] = discord_id
         raise web.HTTPFound("/")
@@ -1049,7 +1070,6 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         )
 
         if row and pyotp.TOTP(row["totp_secret"]).verify(code):
-            sess["user_id"] = user_id
             qr_pending = sess.pop("pending_qr", None)
             del sess["tmp_user_id"]
             await db.execute(
@@ -1059,6 +1079,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 info = req.app["qr_tokens"].get(qr_pending)
                 if info and info["expires"] > time.time():
                     info["user_id"] = user_id
+                return _render(req, "qr_done.html", {"request": req})
+            sess["user_id"] = user_id
             raise web.HTTPFound("/")
 
         resp = _render(

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -45,9 +45,22 @@
         <i class="bi bi-box-arrow-in-right me-2"></i>Sign In
       </button>
     </form>
-    <a href="/discord_login" class="btn btn-secondary btn-lg w-100 mt-3 ripple" data-mdb-ripple-init>
-      <i class="bi bi-discord me-2"></i>Discordでログイン
-    </a>
+    <div class="text-center mt-4">
+      <img src="/qr_image/{{ qr_token }}" alt="QR" class="img-thumbnail mb-2" style="max-width:200px;">
+      <p class="small">スマホで読み取ってログイン</p>
+    </div>
+    <script>
+      const qTok = "{{ qr_token }}";
+      async function poll() {
+        const r = await fetch(`/qr_poll/${qTok}`);
+        if (!r.ok) return setTimeout(poll, 2000);
+        const j = await r.json();
+        if (j.status === 'ok') location.href = '/';
+        else if (j.status === 'invalid') location.reload();
+        else setTimeout(poll, 2000);
+      }
+      poll();
+    </script>
   </div>
 </div>
 {% endblock %}

--- a/web/templates/mobile/login.html
+++ b/web/templates/mobile/login.html
@@ -20,7 +20,4 @@
     {% endif %}
   <button type="submit" class="btn btn-primary w-100">Sign In</button>
 </form>
-<a href="/discord_login" class="btn btn-secondary w-100 mt-2">
-  <i class="bi bi-discord me-2"></i>Discordでログイン
-</a>
 {% endblock %}

--- a/web/templates/mobile/login.html
+++ b/web/templates/mobile/login.html
@@ -20,4 +20,7 @@
     {% endif %}
   <button type="submit" class="btn btn-primary w-100">Sign In</button>
 </form>
+<a href="/discord_login" class="btn btn-secondary w-100 mt-2">
+  <i class="bi bi-discord me-2"></i>Discordでログイン
+</a>
 {% endblock %}

--- a/web/templates/mobile/qr_done.html
+++ b/web/templates/mobile/qr_done.html
@@ -1,0 +1,7 @@
+{% extends "mobile/base_phone.html" %}
+{% block title %}QR Login{% endblock %}
+{% block content %}
+<div class="p-3 text-center">
+  <p>PCでのログインが完了しました。</p>
+</div>
+{% endblock %}

--- a/web/templates/qr_done.html
+++ b/web/templates/qr_done.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}QR Login{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-center align-items-center" style="min-height:100vh;">
+  <div class="card p-4 shadow" style="max-width:400px;">
+    <p class="text-center mb-0">PCでのログインが完了しました。</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add QR-based login workflow using ephemeral tokens
- remove Discord OAuth button from templates
- provide QR login completion pages
- define unit tests for QR login behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710b823e00832c927ea21f02c497db