### PR TITLE
Implement websocket QR login notifications

### DIFF
--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -25,3 +25,13 @@ def test_discord_button_removed():
 def test_qr_done_rendered_on_mobile_flow():
     text = APP_PATH.read_text(encoding='utf-8')
     assert text.count('qr_done.html') >= 4
+
+
+def test_ws_event_handler_added():
+    js = (Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js').read_text(encoding='utf-8')
+    assert "data.action === 'qr_login'" in js
+
+
+def test_visibility_handler_in_template():
+    html = LOGIN_TEMPLATE.read_text(encoding='utf-8')
+    assert 'visibilitychange' in html

--- a/web/app.py
+++ b/web/app.py
@@ -954,6 +954,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             info = req.app["qr_tokens"].get(qr_pending)
             if info and info["expires"] > time.time():
                 info["user_id"] = row["discord_id"]
+                await broadcast_ws({"action": "qr_login", "token": qr_pending})
             return _render(req, "qr_done.html", {"request": req})
 
         sess["user_id"] = row["discord_id"]
@@ -1044,6 +1045,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             info = req.app["qr_tokens"].get(qr_pending)
             if info and info["expires"] > time.time():
                 info["user_id"] = discord_id
+                await broadcast_ws({"action": "qr_login", "token": qr_pending})
             return _render(req, "qr_done.html", {"request": req})
 
         sess["user_id"] = discord_id
@@ -1081,6 +1083,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
                 info = req.app["qr_tokens"].get(qr_pending)
                 if info and info["expires"] > time.time():
                     info["user_id"] = user_id
+                    await broadcast_ws({"action": "qr_login", "token": qr_pending})
                 return _render(req, "qr_done.html", {"request": req})
             sess["user_id"] = user_id
             raise web.HTTPFound("/")
@@ -1114,6 +1117,7 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         sess = await get_session(req)
         if sess.get("user_id"):
             info["user_id"] = sess["user_id"]
+            await broadcast_ws({"action": "qr_login", "token": token})
             return _render(req, "qr_done.html", {"request": req})
         sess["pending_qr"] = token
         raise web.HTTPFound("/login")

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -695,7 +695,15 @@ function connectWs() {
   ws.addEventListener('message', (e) => {
     try {
       const data = JSON.parse(e.data);
-      if (data.action === 'reload') reloadFileList();
+      if (data.action === 'reload') {
+        reloadFileList();
+      } else if (
+        data.action === 'qr_login' &&
+        typeof qTok !== 'undefined' &&
+        data.token === qTok
+      ) {
+        location.href = '/';
+      }
     } catch (err) {
       console.error('ws message error', err);
     }

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -51,14 +51,31 @@
     </div>
     <script>
       const qTok = "{{ qr_token }}";
+      let pollTimer;
       async function poll() {
         const r = await fetch(`/qr_poll/${qTok}`);
-        if (!r.ok) return setTimeout(poll, 2000);
+        if (!r.ok) return schedule();
         const j = await r.json();
         if (j.status === 'ok') location.href = '/';
         else if (j.status === 'invalid') location.reload();
-        else setTimeout(poll, 2000);
+        else schedule();
       }
+      function schedule() {
+        clearTimeout(pollTimer);
+        if (document.visibilityState === 'visible') {
+          pollTimer = setTimeout(poll, 2000);
+        } else {
+          pollTimer = null;
+        }
+      }
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && !pollTimer) {
+          poll();
+        } else if (pollTimer && document.visibilityState !== 'visible') {
+          clearTimeout(pollTimer);
+          pollTimer = null;
+        }
+      });
       poll();
     </script>
   </div>


### PR DESCRIPTION
## Summary
- switch login polling to pause when hidden
- push QR login completion via websocket
- listen for `qr_login` websocket events in main.js
- test login template updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687118380284832c84b1ae09ca25261b