### PR TITLE
Cache qr code images

### DIFF
--- a/tests/test_qr_login.py
+++ b/tests/test_qr_login.py
@@ -35,3 +35,13 @@ def test_ws_event_handler_added():
 def test_visibility_handler_in_template():
     html = LOGIN_TEMPLATE.read_text(encoding='utf-8')
     assert 'visibilitychange' in html
+
+
+def test_login_get_stores_qr_image():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert '"image": buf.getvalue()' in text
+
+
+def test_qr_image_uses_cached_data():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'info.get("image")' in text


### PR DESCRIPTION
## Summary
- cache QR code images in `app["qr_tokens"]`
- use cached image in `qr_image` handler
- add regression tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_687453bf217c832c936c4fed9cf0ed21