### PR TITLE
Add mobile dark mode

### DIFF
--- a/tests/test_mobile_dark_mode.py
+++ b/tests/test_mobile_dark_mode.py
@@ -1,12 +1,37 @@
 from pathlib import Path
 
-BASE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_phone.html'
-CSS  = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-phone.css'
+BASE_PHONE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_phone.html'
+BASE_MOBILE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_mobile.html'
+BASE_FRIENDLY = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_friendly.html'
+
+CSS_PHONE = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-phone.css'
+CSS_MOBILE = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-mobile.css'
+CSS_FRIENDLY = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-mobile-friendly.css'
 
 def test_base_phone_contains_dark_switch():
-    text = BASE.read_text(encoding='utf-8')
+    text = BASE_PHONE.read_text(encoding='utf-8')
+    assert 'darkModeSwitch' in text
+
+def test_base_mobile_contains_dark_switch():
+    text = BASE_MOBILE.read_text(encoding='utf-8')
+    assert 'darkModeSwitch' in text
+
+def test_base_friendly_contains_dark_switch():
+    text = BASE_FRIENDLY.read_text(encoding='utf-8')
     assert 'darkModeSwitch' in text
 
 def test_phone_css_has_dark_mode_rules():
-    text = CSS.read_text(encoding='utf-8')
+    text = CSS_PHONE.read_text(encoding='utf-8')
     assert 'body.dark-mode' in text
+
+def test_mobile_css_has_dark_filename_rule():
+    text = CSS_MOBILE.read_text(encoding='utf-8')
+    assert 'body.dark-mode .file-card .file-name' in text
+
+def test_friendly_css_has_dark_filename_rule():
+    text = CSS_FRIENDLY.read_text(encoding='utf-8')
+    assert 'body.dark-mode .file-card .file-name' in text
+
+def test_phone_css_has_dark_filename_rule():
+    text = CSS_PHONE.read_text(encoding='utf-8')
+    assert 'body.dark-mode .file-card .file-name' in text

--- a/tests/test_mobile_dark_mode.py
+++ b/tests/test_mobile_dark_mode.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'base_phone.html'
+CSS  = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-phone.css'
+
+def test_base_phone_contains_dark_switch():
+    text = BASE.read_text(encoding='utf-8')
+    assert 'darkModeSwitch' in text
+
+def test_phone_css_has_dark_mode_rules():
+    text = CSS.read_text(encoding='utf-8')
+    assert 'body.dark-mode' in text

--- a/tests/test_shared_dark_mode.py
+++ b/tests/test_shared_dark_mode.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+CSS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-fresh.css'
+
+
+def test_shared_index_dark_mode_link_color():
+    text = CSS_PATH.read_text(encoding='utf-8')
+    assert 'body.dark-mode a.list-group-item-action' in text
+    assert 'var(--text-color-dark)' in text

--- a/web/static/css/style-fresh.css
+++ b/web/static/css/style-fresh.css
@@ -224,6 +224,14 @@ body.dark-mode a:hover {
     color: #88b0f2 !important;
 }
 
+/* 共有フォルダ一覧のリンク色をダークモード用に調整 */
+body.dark-mode a.list-group-item-action {
+  color: var(--text-color-dark) !important;
+}
+body.dark-mode a.list-group-item-action:hover {
+  color: var(--link-color-dark) !important;
+}
+
 /* ── リストグループ（index.html／folder_view）のダークモード対応 ── */
 /* 通常（ライト） */
 .list-group {

--- a/web/static/css/style-mobile-friendly.css
+++ b/web/static/css/style-mobile-friendly.css
@@ -43,3 +43,6 @@ body.dark-mode .btn:hover {
   background-color: #42a5f5;
   border-color: #42a5f5;
 }
+body.dark-mode .file-card .file-name {
+  color: #f5f5f5;
+}

--- a/web/static/css/style-mobile-friendly.css
+++ b/web/static/css/style-mobile-friendly.css
@@ -25,3 +25,21 @@ body {
   padding: 0.75rem;
   font-size: 0.95rem;
 }
+
+/* --- Dark Mode --- */
+body.dark-mode {
+  background: #121212;
+  color: #f5f5f5;
+}
+body.dark-mode .card {
+  background: #2e3038;
+  border-color: #444556;
+}
+body.dark-mode .btn {
+  background-color: #64b5f6;
+  border-color: #64b5f6;
+}
+body.dark-mode .btn:hover {
+  background-color: #42a5f5;
+  border-color: #42a5f5;
+}

--- a/web/static/css/style-mobile.css
+++ b/web/static/css/style-mobile.css
@@ -43,3 +43,6 @@ body.dark-mode .btn:hover {
   background-color: #42a5f5;
   border-color: #42a5f5;
 }
+body.dark-mode .file-card .file-name {
+  color: #f5f5f5;
+}

--- a/web/static/css/style-mobile.css
+++ b/web/static/css/style-mobile.css
@@ -25,3 +25,21 @@ body {
   font-weight: bold;
 }
 
+
+/* --- Dark Mode --- */
+body.dark-mode {
+  background: #121212;
+  color: #f5f5f5;
+}
+body.dark-mode .card {
+  background: #2e3038;
+  border-color: #444556;
+}
+body.dark-mode .btn {
+  background-color: #64b5f6;
+  border-color: #64b5f6;
+}
+body.dark-mode .btn:hover {
+  background-color: #42a5f5;
+  border-color: #42a5f5;
+}

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -105,3 +105,30 @@ main {
   margin-top: 0.25rem;
   font-size: 0.75rem;
 }
+
+/* --- Dark Mode --- */
+body.dark-mode {
+  background: #121212;
+  color: #f5f5f5;
+}
+body.dark-mode .card {
+  background: #2e3038;
+  border-color: #444556;
+}
+body.dark-mode .btn-primary {
+  background-color: #64b5f6;
+  border-color: #64b5f6;
+}
+body.dark-mode .btn-primary:hover {
+  background-color: #42a5f5;
+  border-color: #42a5f5;
+}
+body.dark-mode .form-control {
+  background-color: #3a3c45;
+  border-color: #444556;
+  color: #ffffff;
+}
+body.dark-mode .form-control:focus {
+  box-shadow: 0 0 6px #64b5f6;
+  border-color: #64b5f6;
+}

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -132,3 +132,6 @@ body.dark-mode .form-control:focus {
   box-shadow: 0 0 6px #64b5f6;
   border-color: #64b5f6;
 }
+body.dark-mode .file-card .file-name {
+  color: #f5f5f5;
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -50,7 +50,7 @@
     <!-- Dark Mode スイッチ -->
     <div class="form-check form-switch text-white me-3">
       <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-      <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      <label class="form-check-label" for="darkModeSwitch">Dark</label>
     </div>
     <a href="/logout" class="btn btn-sm btn-danger">Logout</a>
   </div>

--- a/web/templates/base_public.html
+++ b/web/templates/base_public.html
@@ -48,7 +48,7 @@
     <!-- Dark Mode スイッチ -->
     <div class="form-check form-switch text-white me-3">
       <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-      <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      <label class="form-check-label" for="darkModeSwitch">Dark</label>
     </div>
   </div>
   {% endif %}

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -14,7 +14,7 @@
 <!-- Dark Mode Switch for Login -->
 <div class="form-check form-switch position-fixed top-0 end-0 m-3 text-white">
   <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-  <label class="form-check-label" for="darkModeSwitch">🌙</label>
+  <label class="form-check-label" for="darkModeSwitch">Dark</label>
 </div>
 <div class="d-flex justify-content-center align-items-center" style="min-height: 100vh;">
   <div class="card p-4 shadow-2-strong animate__animated animate__fadeIn" style="width: 100%; max-width: 400px;">

--- a/web/templates/mobile/base_friendly.html
+++ b/web/templates/mobile/base_friendly.html
@@ -20,7 +20,7 @@
     <div class="d-flex align-items-center">
       <div class="form-check form-switch text-white me-2">
         <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-        <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      <label class="form-check-label" for="darkModeSwitch">Dark</label>
       </div>
       {% if user_id %}
       <a href="/logout" class="btn btn-light btn-sm">Logout</a>

--- a/web/templates/mobile/base_friendly.html
+++ b/web/templates/mobile/base_friendly.html
@@ -15,11 +15,17 @@
 </head>
 <body>
 <nav class="navbar navbar-dark bg-primary py-2">
-  <div class="container-fluid justify-content-between">
+  <div class="container-fluid d-flex align-items-center justify-content-between">
     <span class="navbar-brand mb-0 h1">WDS</span>
-    {% if user_id %}
-    <a href="/logout" class="btn btn-light btn-sm">Logout</a>
-    {% endif %}
+    <div class="d-flex align-items-center">
+      <div class="form-check form-switch text-white me-2">
+        <input class="form-check-input" type="checkbox" id="darkModeSwitch">
+        <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      </div>
+      {% if user_id %}
+      <a href="/logout" class="btn btn-light btn-sm">Logout</a>
+      {% endif %}
+    </div>
   </div>
 </nav>
 <main class="container py-4">

--- a/web/templates/mobile/base_mobile.html
+++ b/web/templates/mobile/base_mobile.html
@@ -22,7 +22,7 @@
     <div class="d-flex align-items-center">
       <div class="form-check form-switch text-white me-2">
         <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-        <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      <label class="form-check-label" for="darkModeSwitch">Dark</label>
       </div>
       {% if user_id %}
       <a href="/logout" class="btn btn-sm btn-danger">Logout</a>

--- a/web/templates/mobile/base_mobile.html
+++ b/web/templates/mobile/base_mobile.html
@@ -17,11 +17,17 @@
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
-  <div class="container-fluid">
+  <div class="container-fluid d-flex align-items-center justify-content-between">
     <span class="navbar-brand">WDS</span>
-    {% if user_id %}
-    <a href="/logout" class="btn btn-sm btn-danger">Logout</a>
-    {% endif %}
+    <div class="d-flex align-items-center">
+      <div class="form-check form-switch text-white me-2">
+        <input class="form-check-input" type="checkbox" id="darkModeSwitch">
+        <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      </div>
+      {% if user_id %}
+      <a href="/logout" class="btn btn-sm btn-danger">Logout</a>
+      {% endif %}
+    </div>
   </div>
 </nav>
 <main class="container py-4">

--- a/web/templates/mobile/base_phone.html
+++ b/web/templates/mobile/base_phone.html
@@ -21,7 +21,7 @@
     <div class="d-flex align-items-center">
       <div class="form-check form-switch text-white me-2">
         <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-        <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      <label class="form-check-label" for="darkModeSwitch">Dark</label>
       </div>
       {% if user_id %}
       <a href="/logout" class="btn btn-sm btn-danger">Logout</a>

--- a/web/templates/mobile/base_phone.html
+++ b/web/templates/mobile/base_phone.html
@@ -16,11 +16,17 @@
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
-  <div class="container-fluid">
+  <div class="container-fluid d-flex align-items-center justify-content-between">
     <span class="navbar-brand">WDS</span>
-    {% if user_id %}
-    <a href="/logout" class="btn btn-sm btn-danger">Logout</a>
-    {% endif %}
+    <div class="d-flex align-items-center">
+      <div class="form-check form-switch text-white me-2">
+        <input class="form-check-input" type="checkbox" id="darkModeSwitch">
+        <label class="form-check-label" for="darkModeSwitch">🌙</label>
+      </div>
+      {% if user_id %}
+      <a href="/logout" class="btn btn-sm btn-danger">Logout</a>
+      {% endif %}
+    </div>
   </div>
 </nav>
 <!-- コピー完了トースト -->

--- a/web/templates/totp.html
+++ b/web/templates/totp.html
@@ -9,7 +9,7 @@
 <!-- Dark Mode Switch for TOTP -->
 <div class="form-check form-switch position-fixed top-0 end-0 m-3 text-white">
   <input class="form-check-input" type="checkbox" id="darkModeSwitch">
-  <label class="form-check-label" for="darkModeSwitch">🌙</label>
+  <label class="form-check-label" for="darkModeSwitch">Dark</label>
 </div>
 
 <div class="d-flex justify-content-center align-items-center" style="min-height: 100vh;">


### PR DESCRIPTION
## Summary
- support dark mode on all mobile templates
- style dark mode for mobile CSS
- test presence of dark mode switch and CSS rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687489202668832ca0ccb979a914e291