### PR TITLE
PC版UIを新デザインに更新

### DIFF
--- a/web/static/css/style-fresh.css
+++ b/web/static/css/style-fresh.css
@@ -2,48 +2,48 @@
   Unified Theme for index.html（改善版 + login画面背景 + /static/api対応）
 ────────────────────────────────────*/
 :root {
-  --bg-gradient-light: linear-gradient(135deg, #fef6ff, #e3f2fd);
-  --bg-gradient-dark: linear-gradient(135deg, #1f1a2e, #2a2143);
-  --login-bg-light: linear-gradient(135deg, #f6e7fe, #d1f4ff);
-  --login-bg-dark: linear-gradient(135deg, #2a2143, #1f1a2e);
+  --bg-gradient-light: linear-gradient(135deg, #f0faff, #d6efff);
+  --bg-gradient-dark: linear-gradient(135deg, #15203b, #000814);
+  --login-bg-light: linear-gradient(135deg, #cfe9ff, #e0f7ff);
+  --login-bg-dark: linear-gradient(135deg, #1b2748, #000f2d);
 
   --card-bg-light: #ffffff;
-  --card-bg-dark: #2d233c;
-  --card-border-light: #dfd2f1;
-  --card-border-dark: #453257;
-  --glass-bg-light: rgba(255, 255, 255, 0.8);
-  --glass-bg-dark: rgba(45, 35, 60, 0.85);
-  --shadow-light: rgba(0, 0, 0, 0.1);
-  --shadow-dark: rgba(0, 0, 0, 0.6);
+  --card-bg-dark: #1c2130;
+  --card-border-light: #cfe2ff;
+  --card-border-dark: #2b344a;
+  --glass-bg-light: rgba(255, 255, 255, 0.9);
+  --glass-bg-dark: rgba(28, 33, 48, 0.9);
+  --shadow-light: rgba(0, 0, 0, 0.05);
+  --shadow-dark: rgba(0, 0, 0, 0.7);
 
-  --text-color-light: #1b1b1b;
-  --text-color-dark: #f8f8f8;
+  --text-color-light: #10213b;
+  --text-color-dark: #eaf4ff;
 
-  --link-color-light: #7d35ff;
-  --link-color-dark: #b38fff;
+  --link-color-light: #0d6efd;
+  --link-color-dark: #86b7fe;
 
-  --btn-bg-light: #8e3bf8;
-  --btn-bg-dark: #aa7cfb;
-  --btn-hover-light: #6d2bcf;
-  --btn-hover-dark: #9d68f6;
+  --btn-bg-light: #0d6efd;
+  --btn-bg-dark: #4e7fff;
+  --btn-hover-light: #0b5ed7;
+  --btn-hover-dark: #6fa8fe;
 
-  --table-header-bg-light: #f9f0ff;
-  --table-header-bg-dark: #3c2b54;
+  --table-header-bg-light: #e7f1ff;
+  --table-header-bg-dark: #263755;
   --table-header-color: #212529;
   --table-header-color-dark: #ffffff;
   --table-row-bg-light: #ffffff;
-  --table-row-bg-dark: #2d233c;
-  --table-row-hover-dark: #403051;
-  --table-text-color-dark: #e8eaf0;
+  --table-row-bg-dark: #1c2130;
+  --table-row-hover-dark: #2e3b56;
+  --table-text-color-dark: #eaf4ff;
 
-  --input-bg-light: #faf9fc;
-  --input-bg-dark: #423052;
+  --input-bg-light: #f8fbff;
+  --input-bg-dark: #2b344a;
   --input-text-dark: #ffffff;
 
   --transition-speed: 0.3s;
   --modal-overlay: rgba(0,0,0,0.6);
-  --accent-start: #b54cff;
-  --accent-end: #ff4b9b;
+  --accent-start: #4ca1ff;
+  --accent-end: #007bff;
 }
 
 body {
@@ -419,3 +419,19 @@ body.dark-mode #fileSearch {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ---- New Layout Elements ---- */
+.navbar-custom {
+  background: linear-gradient(90deg, var(--accent-start), var(--accent-end));
+}
+body.dark-mode .navbar-custom {
+  background: #1c2130;
+}
+.navbar-custom .navbar-brand {
+  font-weight: 600;
+  font-size: 1.4rem;
+}
+.container-main {
+  max-width: 1100px;
+}
+

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -43,8 +43,8 @@
 <!-- 画面右下に表示するトップへ戻るボタン -->
 <button id="scrollToTop" aria-label="トップへ戻る">↑</button>
 
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4 px-3">
-  <span class="navbar-brand">WDS</span>
+<nav class="navbar navbar-expand-lg navbar-dark navbar-custom mb-4 px-3">
+  <span class="navbar-brand fw-bold">WDS</span>
   {% if user_id %}
   <div class="ms-auto d-flex align-items-center">
     <!-- Dark Mode スイッチ -->
@@ -93,7 +93,7 @@
   </div>
 </div>
 
-<main class="container-fluid mb-5">
+<main class="container container-main mb-5">
   {% with msgs = get_flashed_messages() %}
     {% if msgs %}
       <div class="alert alert-warning">{{ msgs[0] }}</div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container-fluid py-5">
+<div class="container container-main py-4">
   <!-- ★ パンくずリストで現在位置を明示 -->
   <nav aria-label="breadcrumb" class="mb-3">
     <ol class="breadcrumb">
@@ -27,114 +27,118 @@
 
   <!-- コピー完了トースト -->
   <div class="toast-container position-fixed bottom-0 end-0 p-3">
-    <div id="copyToast" class="toast align-items-center text-white bg-success border-0 animate__animated animate__fadeInRight" 
+    <div id="copyToast" class="toast align-items-center text-white bg-success border-0 animate__animated animate__fadeInRight"
          role="alert" aria-live="assertive" aria-atomic="true">
       <div class="d-flex">
         <div class="toast-body">リンクをコピーしました！</div>
-        <button type="button" class="btn-close btn-close-white me-2 m-auto" 
+        <button type="button" class="btn-close btn-close-white me-2 m-auto"
                 data-mdb-dismiss="toast" aria-label="Close"></button>
       </div>
     </div>
   </div>
 
-  <!-- ウェルカムカード -->
-  <div class="card mb-4 shadow-2-strong tilt animate__animated animate__fadeInDown hover-grow" data-tilt data-tilt-glare data-tilt-max-glare="0.4" style="border-radius: 1rem;">
-    <div class="card-body text-center">
-      <h2 class="card-title mb-0 fw-bold text-primary">ようこそ、{{ username }} さん</h2>
-    </div>
-  </div>
-
-  <div id="subfolderList" class="mb-3">
-    {% if subfolders %}
-    <div class="list-group">
-      {% for f in subfolders %}
-      <div class="list-group-item d-flex justify-content-between align-items-center">
-        <a href="/?folder={{ f.id }}" class="flex-grow-1 text-decoration-none" data-ajax>
-          <i class="bi bi-folder-fill me-2"></i>{{ f.name }}
-        </a>
-        <form method="post" action="/delete_folder/{{ f.id }}" onsubmit="return confirm('削除しますか？');">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-          <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-        </form>
+  <div class="row g-4">
+    <div class="col-lg-4">
+      <!-- ウェルカムカード -->
+      <div class="card mb-4 shadow-2-strong tilt animate__animated animate__fadeInDown hover-grow" data-tilt data-tilt-glare data-tilt-max-glare="0.4" style="border-radius: 1rem;">
+        <div class="card-body text-center">
+          <h2 class="card-title mb-0 fw-bold text-primary">ようこそ、{{ username }} さん</h2>
+        </div>
       </div>
-      {% endfor %}
-    </div>
-    <form method="post" action="/delete_subfolders" class="mt-2" onsubmit="return confirm('本当に全て削除しますか？');">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-      <input type="hidden" name="parent_id" value="{{ folder_id }}">
-      <button type="submit" class="btn btn-danger btn-sm">サブフォルダ全削除</button>
-    </form>
-    {% endif %}
-  </div>
 
-  <!-- アップロードセクション -->
-  <div class="card mb-4 shadow-2-strong tilt animate__animated animate__fadeInUp hover-grow" data-tilt data-tilt-max="10" style="border-radius: 1rem;">
-    <div class="card-header bg-primary text-white">
-      <h5 class="mb-0">ファイルアップロード</h5>
+      <div id="subfolderList" class="mb-3">
+        {% if subfolders %}
+        <div class="list-group">
+          {% for f in subfolders %}
+          <div class="list-group-item d-flex justify-content-between align-items-center">
+            <a href="/?folder={{ f.id }}" class="flex-grow-1 text-decoration-none" data-ajax>
+              <i class="bi bi-folder-fill me-2"></i>{{ f.name }}
+            </a>
+            <form method="post" action="/delete_folder/{{ f.id }}" onsubmit="return confirm('削除しますか？');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+              <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+            </form>
+          </div>
+          {% endfor %}
+        </div>
+        <form method="post" action="/delete_subfolders" class="mt-2" onsubmit="return confirm('本当に全て削除しますか？');">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+          <input type="hidden" name="parent_id" value="{{ folder_id }}">
+          <button type="submit" class="btn btn-danger btn-sm">サブフォルダ全削除</button>
+        </form>
+        {% endif %}
+      </div>
     </div>
-        <!-- ここがドラッグ受け皿 -->
-        <div class="card-body" id="uploadArea">
-          <form id="uploadForm"
-                action="/upload"
-                method="post"
-                enctype="multipart/form-data"
-                onsubmit="return false;">     <!-- ネイティブ送信を止める -->
-            <input type="hidden" name="folder_id" value="{{ folder_id }}" data-shared="0">
-            <div class="row gx-3 align-items-end mb-4">
-              <div class="col-sm-8">
-                <!-- multiple を付ける -->
-                <input type="file" name="file" class="form-control" multiple required>
+
+    <div class="col-lg-8">
+      <!-- アップロードセクション -->
+      <div class="card mb-4 shadow-2-strong tilt animate__animated animate__fadeInUp hover-grow" data-tilt data-tilt-max="10" style="border-radius: 1rem;">
+        <div class="card-header bg-primary text-white">
+          <h5 class="mb-0">ファイルアップロード</h5>
+        </div>
+            <!-- ここがドラッグ受け皿 -->
+            <div class="card-body" id="uploadArea">
+              <form id="uploadForm"
+                    action="/upload"
+                    method="post"
+                    enctype="multipart/form-data"
+                    onsubmit="return false;">
+                <input type="hidden" name="folder_id" value="{{ folder_id }}" data-shared="0">
+                <div class="row gx-3 align-items-end mb-4">
+                  <div class="col-sm-8">
+                    <input type="file" name="file" class="form-control" multiple required>
+                  </div>
+                  <div class="col-sm-4 text-end">
+                    <button type="button"
+                            id="uploadBtn"
+                            class="btn btn-success w-100 ripple"
+                            data-mdb-ripple-init>
+                      <i class="bi bi-cloud-upload-fill me-2"></i>アップロード
+                      <span id="uploadSpinner"
+                            class="spinner-border spinner-border-sm ms-2"
+                            role="status"
+                            style="display:none;"></span>
+                    </button>
+                  </div>
+                </div>
+              </form>
+              <form id="createFolderForm" method="post" action="/create_folder" class="mb-4">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="parent_id" value="{{ folder_id }}">
+                <div class="input-group">
+                  <input type="text" name="name" class="form-control" placeholder="新しいフォルダ名" required>
+                  <button class="btn btn-outline-primary" type="submit">作成</button>
+                </div>
+              </form>
+              <div class="d-flex flex-column flex-sm-row gap-2 mb-3">
+                <a href="/shared" class="btn btn-outline-primary flex-fill">📁 共有フォルダを確認</a>
+                {% if gdrive_enabled %}
+                  {% if gdrive_authorized %}
+                  <a href="/gdrive_import" class="btn btn-outline-success flex-fill">🔄 Google Drive 取り込み</a>
+                  {% else %}
+                  <a href="/gdrive_auth" class="btn btn-outline-warning flex-fill">🔑 Google Drive 連携</a>
+                  {% endif %}
+                {% endif %}
               </div>
-              <div class="col-sm-4 text-end">
-                <!-- type="button" にして、JS のみで送信 -->
-                <button type="button"
-                        id="uploadBtn"
-                        class="btn btn-success w-100 ripple"
-                        data-mdb-ripple-init>
-                  <i class="bi bi-cloud-upload-fill me-2"></i>アップロード
-                  <span id="uploadSpinner"
-                        class="spinner-border spinner-border-sm ms-2"
-                        role="status"
-                        style="display:none;"></span>
-                </button>
+              <div class="text-center text-muted small">
+                ここにファイルをドラッグ＆ドロップしてアップロード
               </div>
-            </div>
-          </form>
-          <form id="createFolderForm" method="post" action="/create_folder" class="mb-4">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-            <input type="hidden" name="parent_id" value="{{ folder_id }}">
-            <div class="input-group">
-              <input type="text" name="name" class="form-control" placeholder="新しいフォルダ名" required>
-              <button class="btn btn-outline-primary" type="submit">作成</button>
-            </div>
-          </form>
-          <div class="d-flex flex-column flex-sm-row gap-2 mb-3">
-            <a href="/shared" class="btn btn-outline-primary flex-fill">📁 共有フォルダを確認</a>
-            {% if gdrive_enabled %}
-              {% if gdrive_authorized %}
-              <a href="/gdrive_import" class="btn btn-outline-success flex-fill">🔄 Google Drive 取り込み</a>
-              {% else %}
-              <a href="/gdrive_auth" class="btn btn-outline-warning flex-fill">🔑 Google Drive 連携</a>
-              {% endif %}
-            {% endif %}
-          </div>
-          <div class="text-center text-muted small">
-            ここにファイルをドラッグ＆ドロップしてアップロード
-          </div>
+        </div>
+              <div class="progress mt-2" id="uploadProgressWrap" style="height:6px; display:none;">
+                <div id="uploadProgressBar"
+                    class="progress-bar bg-success"
+                    role="progressbar"
+                    style="width:0%"
+                    aria-valuemin="0"
+                    aria-valuemax="100"></div>
+              </div>
+      </div>
+      <!-- ファイル一覧セクション -->
+        <div id="fileListContainer">
+            {% include "partials/file_table.html" %}
+        </div>
     </div>
-          <div class="progress mt-2" id="uploadProgressWrap" style="height:6px; display:none;">
-            <div id="uploadProgressBar"
-                class="progress-bar bg-success"
-                role="progressbar"
-                style="width:0%"
-                aria-valuemin="0"
-                aria-valuemax="100"></div>
-          </div>
   </div>
-  <!-- ファイル一覧セクション -->
-    <div id="fileListContainer">
-        {% include "partials/file_table.html" %}
-    </div>
 </div>
 
 <!-- モーダル -->


### PR DESCRIPTION
## Summary
- add modern blue theme and layout utilities in `style-fresh.css`
- update base layout with `navbar-custom` and container width class
- rework `index.html` into a two-column layout for improved usability

## Testing
- `pytest -q` *(fails: pytest unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68748996de08832cbbda905ede8c5805