### PR TITLE
Fix CSP to allow Google Fonts

### DIFF
--- a/tests/test_csp_policy.py
+++ b/tests/test_csp_policy.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_csp_allows_google_fonts():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'https://fonts.googleapis.com' in text
+    assert 'https://fonts.gstatic.com' in text

--- a/web/app.py
+++ b/web/app.py
@@ -339,9 +339,9 @@ async def auth_mw(request: web.Request, handler):
 CSP_POLICY = (
     "default-src 'self'; "
     "script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com 'unsafe-inline'; "
-    "style-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com 'unsafe-inline'; "
+    "style-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com 'unsafe-inline'; "
     "img-src 'self' data:; "
-    "font-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; "
+    "font-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.gstatic.com; "
     "connect-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com;"
 )
 


### PR DESCRIPTION
## Summary
- allow Google Fonts in Content Security Policy
- test that CSP includes Google Fonts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749d8cf988832c9cd21beb118f0d79