### PR TITLE
Improve preview performance

### DIFF
--- a/tests/test_lazy_preview.py
+++ b/tests/test_lazy_preview.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+PARTIALS = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'partials'
+MOBILE_PARTIALS = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'partials'
+
+def read(p):
+    return p.read_text(encoding='utf-8')
+
+def test_lazy_preview_class_exists():
+    files = [
+        PARTIALS / 'file_table.html',
+        PARTIALS / 'shared_folder_table.html',
+        MOBILE_PARTIALS / 'file_cards.html',
+        MOBILE_PARTIALS / 'shared_folder_cards.html',
+    ]
+    for f in files:
+        text = read(f)
+        assert 'lazy-preview' in text

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -54,3 +54,13 @@ def test_download_requests_not_cached():
         re.S,
     )
     assert pattern.search(sw)
+
+
+def test_previews_cached_with_stale_while_revalidate():
+    sw = read_sw()
+    for path in ['/previews/', '/hls/']:
+        pattern = re.compile(
+            rf"url\.pathname\.startsWith\('{path}'\).*staleWhileRevalidate",
+            re.S,
+        )
+        assert pattern.search(sw)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -44,6 +44,24 @@ function previewError(img) {
   img.classList.add('d-none');
 }
 
+// Intersection Observer で遅延読込
+function initLazyPreview(root = document) {
+  if (!('IntersectionObserver' in window)) return;
+  const targets = root.querySelectorAll('img.lazy-preview[data-src], video.lazy-preview[data-src]');
+  const opts = { rootMargin: '200px 0px' };
+  const io = new IntersectionObserver((entries, observer) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        el.src = el.dataset.src;
+        el.removeAttribute('data-src');
+        observer.unobserve(el);
+      }
+    });
+  }, opts);
+  targets.forEach(el => io.observe(el));
+}
+
 /*─────────────────────────────
     History-API / AJAX ナビゲータ
 ─────────────────────────────*/
@@ -137,6 +155,8 @@ async function reloadFileList() {
   if (q) filterTable(q);
   // 再描画後に期限カウントダウン再起動
   startExpirationCountdowns();
+  // Intersection Observer を再登録
+  initLazyPreview(container);
   // 残り期限のカウントダウンを再起動
   // 共有トグルのクリックはイベントデリゲーションで処理するため
   // ここでは個別のイベント登録を行わない
@@ -533,6 +553,7 @@ function rebindDynamicHandlers() {
   if (typeof startExpirationCountdowns === "function") {
     startExpirationCountdowns();
   }
+  initLazyPreview();
 }
 
 // 初回ロード時にも呼ぶ

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -58,6 +58,14 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (
+    url.pathname.startsWith('/previews/') ||
+    url.pathname.startsWith('/hls/')
+  ) {
+    event.respondWith(staleWhileRevalidate(request));
+    return;
+  }
+
+  if (
     url.pathname.startsWith('/download') ||
     url.pathname.startsWith('/shared/download')
   ) {

--- a/web/templates/mobile/partials/file_cards.html
+++ b/web/templates/mobile/partials/file_cards.html
@@ -4,9 +4,9 @@
   <div class="card file-card">
     <div class="card-body">
       {% if f.is_image %}
-      <img src="{{ f.preview_url }}" loading="lazy" class="rounded" onerror="previewError(this)">
+      <img data-src="{{ f.preview_url }}" loading="lazy" class="rounded lazy-preview" onerror="previewError(this)">
       {% elif f.is_video %}
-      <video src="{{ f.preview_url }}" preload="metadata" class="rounded" muted autoplay loop playsinline></video>
+      <video data-src="{{ f.preview_url }}" preload="metadata" class="rounded lazy-preview" muted autoplay loop playsinline></video>
       {% else %}
       <i class="bi {{ icon_by_ext(f.original_name) }} fs-3 text-secondary"></i>
       {% endif %}

--- a/web/templates/mobile/partials/shared_folder_cards.html
+++ b/web/templates/mobile/partials/shared_folder_cards.html
@@ -4,9 +4,9 @@
   <div class="card file-card">
     <div class="card-body">
       {% if f.is_image %}
-      <img src="{{ f.preview_url }}" loading="lazy" class="rounded" onerror="previewError(this)">
+      <img data-src="{{ f.preview_url }}" loading="lazy" class="rounded lazy-preview" onerror="previewError(this)">
       {% elif f.is_video %}
-      <video src="{{ f.preview_url }}" preload="metadata" class="rounded" muted autoplay loop playsinline></video>
+      <video data-src="{{ f.preview_url }}" preload="metadata" class="rounded lazy-preview" muted autoplay loop playsinline></video>
       {% else %}
       <i class="bi {{ icon_by_ext(f.original_name) }} fs-3 text-secondary"></i>
       {% endif %}

--- a/web/templates/partials/file_table.html
+++ b/web/templates/partials/file_table.html
@@ -47,8 +47,8 @@
                   <button class="btn btn-outline-secondary p-0 border-0"
                           style="width:60px;height:60px"
                           onclick="showFull('{{ f.download_path }}?preview=1'); return false;">
-                    <img src="{{ f.preview_url }}" loading="lazy"
-                          class="img-fluid rounded" style="max-height:60px;"
+                    <img data-src="{{ f.preview_url }}" loading="lazy"
+                          class="img-fluid rounded lazy-preview" style="max-height:60px;"
                           onerror="previewError(this)">
                     <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                   </button>
@@ -59,8 +59,8 @@
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
                             onclick="showFull('{{ f.hls_url or (f.download_path + '?preview=1') }}', true)">
-                      <video src="{{ f.preview_url }}" preload="metadata" loading="lazy"
-                              class="w-100 h-100 rounded object-fit-cover"
+                      <video data-src="{{ f.preview_url }}" preload="metadata" loading="lazy"
+                              class="w-100 h-100 rounded object-fit-cover lazy-preview"
                               style="max-width:60px;max-height:60px;"
                               muted autoplay loop playsinline onerror="previewError(this)"></video>
                       </button>
@@ -71,8 +71,8 @@
                     <button class="btn btn-outline-secondary p-0 border-0"
                             style="width:60px;height:60px"
                             onclick="showFull('{{ f.preview_url }}'); return false;">
-                    <img src="{{ f.preview_url }}" loading="lazy"
-                         class="img-fluid rounded" style="max-height:60px;"
+                    <img data-src="{{ f.preview_url }}" loading="lazy"
+                         class="img-fluid rounded lazy-preview" style="max-height:60px;"
                          onerror="previewError(this)">
                     <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                   </button>

--- a/web/templates/partials/shared_folder_table.html
+++ b/web/templates/partials/shared_folder_table.html
@@ -47,8 +47,8 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.download_path }}?preview=1'); return false;">
-                  <img src="{{ f.preview_url }}" loading="lazy"
-                      class="img-fluid rounded"
+                  <img data-src="{{ f.preview_url }}" loading="lazy"
+                      class="img-fluid rounded lazy-preview"
                       style="max-height:60px;" onerror="previewError(this)">
                   <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                 </button>
@@ -59,8 +59,8 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.hls_url or (f.download_path + '?preview=1') }}', true); return false;">
-                  <video src="{{ f.preview_url }}" preload="metadata" loading="lazy"
-                          class="w-100 h-100 rounded object-fit-cover"
+                  <video data-src="{{ f.preview_url }}" preload="metadata" loading="lazy"
+                          class="w-100 h-100 rounded object-fit-cover lazy-preview"
                           style="max-width:60px;max-height:60px;"
                           muted autoplay loop playsinline onerror="previewError(this)"></video>
                 </button>
@@ -71,8 +71,8 @@
                 <button class="btn btn-outline-secondary p-0 border-0"
                         style="width:60px;height:60px"
                         onclick="showFull('{{ f.preview_url }}'); return false;">
-                  <img src="{{ f.preview_url }}" loading="lazy"
-                       class="img-fluid rounded" style="max-height:60px;" onerror="previewError(this)">
+                  <img data-src="{{ f.preview_url }}" loading="lazy"
+                       class="img-fluid rounded lazy-preview" style="max-height:60px;" onerror="previewError(this)">
                   <i class="bi {{ icon_by_ext(f.original_name) }} fs-2 text-secondary fallback-icon d-none"></i>
                 </button>
                   <span class="file-name" data-file-id="{{ f.id }}" title="{{ f.original_name }}">{{ f.original_name }}</span>


### PR DESCRIPTION
## Summary
- cache preview images & HLS files in Service Worker
- load previews via IntersectionObserver
- add `lazy-preview` class in templates for IntersectionObserver
- test for service worker preview caching
- test for new lazy preview markup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749dd89244832c832496fd839eedc6