### PR TITLE
Handle PC expiration line break

### DIFF
--- a/tests/test_pc_expiration_linebreak.py
+++ b/tests/test_pc_expiration_linebreak.py
@@ -5,13 +5,12 @@ JS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.
 CSS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-fresh.css'
 
 
-def test_format_expiration_has_newline():
+def test_format_expiration_no_newline():
     text = JS_PATH.read_text(encoding='utf-8')
     pattern = re.compile(r'\$\{mins\}分\\n\$\{secs\}秒`')
-    assert pattern.search(text)
+    assert not pattern.search(text)
 
 
-def test_pc_css_uses_pre_line():
+def test_pc_css_no_pre_line():
     text = CSS_PATH.read_text(encoding='utf-8')
-    pattern = re.compile(r'\.expiration-cell\s+small\s*{[^}]*white-space:\s*pre-line;', re.S)
-    assert pattern.search(text)
+    assert 'pre-line' not in text

--- a/tests/test_pc_expiration_linebreak.py
+++ b/tests/test_pc_expiration_linebreak.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import re
+
+JS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'js' / 'main.js'
+CSS_PATH = Path(__file__).resolve().parents[1] / 'web' / 'static' / 'css' / 'style-fresh.css'
+
+
+def test_format_expiration_has_newline():
+    text = JS_PATH.read_text(encoding='utf-8')
+    pattern = re.compile(r'\$\{mins\}分\\n\$\{secs\}秒`')
+    assert pattern.search(text)
+
+
+def test_pc_css_uses_pre_line():
+    text = CSS_PATH.read_text(encoding='utf-8')
+    pattern = re.compile(r'\.expiration-cell\s+small\s*{[^}]*white-space:\s*pre-line;', re.S)
+    assert pattern.search(text)

--- a/web/static/css/style-fresh.css
+++ b/web/static/css/style-fresh.css
@@ -428,7 +428,3 @@ body.dark-mode #fileSearch {
   white-space: nowrap;
 }
 
-/* PC版では共有期限の分と秒を改行して表示 */
-.expiration-cell small {
-  white-space: pre-line;
-}

--- a/web/static/css/style-fresh.css
+++ b/web/static/css/style-fresh.css
@@ -427,3 +427,8 @@ body.dark-mode #fileSearch {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* PC版では共有期限の分と秒を改行して表示 */
+.expiration-cell small {
+  white-space: pre-line;
+}

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -281,11 +281,8 @@ function formatExpiration(sec) {
   const parts = [];
   if (days) parts.push(`${days}日`);
   if (hrs)  parts.push(`${hrs}時間`);
-  if (mins) {
-    parts.push(`${mins}分\n${secs}秒`);
-  } else {
-    parts.push(`${secs}秒`);
-  }
+  if (mins) parts.push(`${mins}分`);
+  parts.push(`${secs}秒`);
   return parts.join("");
 }
 

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -281,8 +281,11 @@ function formatExpiration(sec) {
   const parts = [];
   if (days) parts.push(`${days}日`);
   if (hrs)  parts.push(`${hrs}時間`);
-  if (mins) parts.push(`${mins}分`);
-  parts.push(`${secs}秒`);
+  if (mins) {
+    parts.push(`${mins}分\n${secs}秒`);
+  } else {
+    parts.push(`${secs}秒`);
+  }
   return parts.join("");
 }
 


### PR DESCRIPTION
## Summary
- add newline between minutes and seconds for PC
- support newline via CSS
- test JS and CSS for newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a5e81180832c8fd08dfb82094955