### PR TITLE
Fix Google Drive auth redirect loop

### DIFF
--- a/tests/test_gdrive_callback.py
+++ b/tests/test_gdrive_callback.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_gdrive_flows_store_user():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'app["gdrive_flows"][state] = (flow, discord_id)' in text
+
+
+def test_gdrive_callback_fallback():
+    text = APP_PATH.read_text(encoding='utf-8')
+    assert 'data = app["gdrive_flows"].pop(state or sess_state, None)' in text
+    assert 'discord_id = sess.get("user_id", stored_id)' in text

--- a/web/app.py
+++ b/web/app.py
@@ -1176,22 +1176,24 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
             include_granted_scopes="true",
             prompt="consent",
         )
-        app["gdrive_flows"][state] = flow
+        # state と紐づけてユーザーIDも保持しておく
+        app["gdrive_flows"][state] = (flow, discord_id)
         sess = await aiohttp_session.get_session(req)
         sess["gdrive_state"] = state
         raise web.HTTPFound(auth_url)
 
     async def gdrive_callback(req: web.Request):
         sess = await aiohttp_session.get_session(req)
-        discord_id = sess.get("user_id")
-        if not discord_id:
-            raise web.HTTPFound("/login")
         state = req.query.get("state")
         sess_state = sess.pop("gdrive_state", None)
-        if not state or sess_state != state:
+        data = app["gdrive_flows"].pop(state or sess_state, None)
+        if not data:
             return web.Response(text="invalid state", status=400)
-        flow = app["gdrive_flows"].pop(state, None)
-        if not flow:
+        flow, stored_id = data
+        discord_id = sess.get("user_id", stored_id)
+        if not discord_id:
+            raise web.HTTPFound("/login")
+        if state and sess_state and sess_state != state:
             return web.Response(text="invalid state", status=400)
         flow.fetch_token(code=req.query.get("code"))
         creds = flow.credentials


### PR DESCRIPTION
## Summary
- persist `discord_id` with OAuth flow so callback works without session
- read fallback user info during `gdrive_callback`
- allow missing query state by checking session fallback
- add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874bb324450832ca3834b9eaf1461bc