### PR TITLE
Implement preview reload broadcast

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -64,3 +64,8 @@ def test_previews_cached_with_stale_while_revalidate():
             re.S,
         )
         assert pattern.search(sw)
+
+def test_stale_while_revalidate_checks_status():
+    sw = read_sw()
+    pattern = re.compile(r"res\.ok\)\s*\{\s*cache.put", re.S)
+    assert pattern.search(sw)

--- a/tests/test_task_worker_reload.py
+++ b/tests/test_task_worker_reload.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import re
+
+APP = Path(__file__).resolve().parents[1] / 'web' / 'app.py'
+
+
+def test_task_worker_triggers_reload():
+    text = APP.read_text(encoding='utf-8')
+    pattern = re.compile(r"async def _task_worker.*broadcast_ws\(\{\"action\": \"reload\"\}\)", re.S)
+    assert pattern.search(text)

--- a/web/app.py
+++ b/web/app.py
@@ -306,6 +306,7 @@ async def _task_worker(app: web.Application):
             log.exception("Background task failed: %s", e)
         finally:
             queue.task_done()
+            await app["broadcast_ws"]({"action": "reload"})
 
 
 # ─────────────── Middleware ───────────────
@@ -833,10 +834,13 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
     app["gdrive_flows"] = {}
     app["discord_states"] = set()
     app["qr_tokens"] = {}
+    app["task_queue"] = asyncio.Queue()
+    app["broadcast_ws"] = None  # placeholder, assigned later
 
     async def on_startup(app: web.Application):
         await init_db(DB_PATH)
         await db.open()
+        app["worker"] = asyncio.create_task(_task_worker(app))
 
     async def on_cleanup(app: web.Application):
         worker = app.get("worker")
@@ -891,6 +895,8 @@ def create_app(bot: Optional[discord.Client] = None) -> web.Application:
         for ws in list(app["websockets"]):
             if not ws.closed:
                 await ws.send_json(message)
+
+    app["broadcast_ws"] = broadcast_ws
 
     # handlers
     async def health(req):

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -97,7 +97,9 @@ async function staleWhileRevalidate(request) {
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(request);
   const fetchPromise = fetch(request).then(res => {
-    cache.put(request, res.clone());
+    if (res.ok) {
+      cache.put(request, res.clone());
+    }
     return res;
   }).catch(() => cached);
   return cached || fetchPromise;


### PR DESCRIPTION
## Summary
- notify clients via WebSocket when background preview tasks finish
- avoid caching failed preview requests in the service worker
- start task worker on startup and expose broadcast function
- test for the task worker reload broadcast
- test service worker status check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875aab281b8832c83bd0284e2f388c0