### PR TITLE
Fix folder deletion refresh

### DIFF
--- a/tests/test_delete_folder_reload.py
+++ b/tests/test_delete_folder_reload.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+TEMPLATE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'index.html'
+MOBILE_TEMPLATE = Path(__file__).resolve().parents[1] / 'web' / 'templates' / 'mobile' / 'index.html'
+
+
+def test_folder_delete_forms_have_class():
+    text = TEMPLATE.read_text(encoding='utf-8')
+    mobile = MOBILE_TEMPLATE.read_text(encoding='utf-8')
+    assert 'action="/delete_folder/' in text
+    assert 'class="delete-form"' in text
+    assert 'action="/delete_subfolders"' in text
+    assert 'class="delete-form"' in text
+    assert 'action="/delete_folder/' in mobile
+    assert 'class="delete-form"' in mobile
+    assert 'action="/delete_subfolders"' in mobile
+    assert 'class="delete-form"' in mobile

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -52,14 +52,14 @@
         <a href="/?folder={{ f.id }}" class="flex-grow-1 text-decoration-none" data-ajax>
           <i class="bi bi-folder-fill me-2"></i>{{ f.name }}
         </a>
-        <form method="post" action="/delete_folder/{{ f.id }}" onsubmit="return confirm('削除しますか？');">
+        <form method="post" action="/delete_folder/{{ f.id }}" class="delete-form" onsubmit="return confirm('削除しますか？');">
           <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
           <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
         </form>
       </div>
       {% endfor %}
     </div>
-    <form method="post" action="/delete_subfolders" class="mt-2" onsubmit="return confirm('本当に全て削除しますか？');">
+    <form method="post" action="/delete_subfolders" class="mt-2 delete-form" onsubmit="return confirm('本当に全て削除しますか？');">
       <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
       <input type="hidden" name="parent_id" value="{{ folder_id }}">
       <button type="submit" class="btn btn-danger btn-sm">サブフォルダ全削除</button>

--- a/web/templates/mobile/index.html
+++ b/web/templates/mobile/index.html
@@ -28,14 +28,14 @@
       <a href="/mobile?folder={{ f.id }}" class="flex-grow-1 text-decoration-none">
         <i class="bi bi-folder-fill me-2"></i>{{ f.name }}
       </a>
-      <form method="post" action="/delete_folder/{{ f.id }}" onsubmit="return confirm('削除しますか？');">
+      <form method="post" action="/delete_folder/{{ f.id }}" class="delete-form" onsubmit="return confirm('削除しますか？');">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <button type="submit" class="btn btn-sm btn-outline-danger">削除</button>
       </form>
     </div>
     {% endfor %}
   </div>
-  <form method="post" action="/delete_subfolders" class="mb-3" onsubmit="return confirm('本当に全て削除しますか？');">
+  <form method="post" action="/delete_subfolders" class="mb-3 delete-form" onsubmit="return confirm('本当に全て削除しますか？');">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
     <input type="hidden" name="parent_id" value="{{ folder_id }}">
     <button class="btn btn-danger btn-sm w-100">サブフォルダ全削除</button>


### PR DESCRIPTION
## Summary
- reload folder list on deletion
- test templates have delete-form class for folder delete forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b4cfe358832c84fde1eac42a7027