### PR TITLE
Add CACHE_VERSION constant for PWA

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -75,3 +75,10 @@ def test_stale_while_revalidate_checks_status():
     sw = read_sw()
     pattern = re.compile(r"res\.ok\)\s*\{\s*cache.put", re.S)
     assert pattern.search(sw)
+
+
+def test_cache_version_variable():
+    sw = read_sw()
+    assert 'const CACHE_VERSION' in sw
+    pattern = re.compile(r"const CACHE_NAME = `wds-cache-\${CACHE_VERSION}`;")
+    assert pattern.search(sw)

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'wds-cache-v3';
+const CACHE_VERSION = 'v4';
+const CACHE_NAME = `wds-cache-${CACHE_VERSION}`;
 const OFFLINE_PAGE = '/offline';
 const OFFLINE_URLS = [
   '/',


### PR DESCRIPTION
## Summary
- add CACHE_VERSION constant and build CACHE_NAME using it
- test for CACHE_VERSION in service worker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ca7bd160832c869b46877db34bda