### PR TITLE
Fix download navigation issue in service worker

### DIFF
--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -56,6 +56,13 @@ def test_download_requests_not_cached():
     assert pattern.search(sw)
 
 
+def test_download_check_before_navigate():
+    sw = read_sw()
+    download_pos = sw.index("url.pathname.startsWith('/download')")
+    navigate_pos = sw.index("request.mode === 'navigate'")
+    assert download_pos < navigate_pos
+
+
 def test_previews_cached_with_stale_while_revalidate():
     sw = read_sw()
     for path in ['/previews/', '/hls/']:

--- a/web/static/service-worker.js
+++ b/web/static/service-worker.js
@@ -48,6 +48,14 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  if (
+    url.pathname.startsWith('/download') ||
+    url.pathname.startsWith('/shared/download')
+  ) {
+    event.respondWith(fetch(request));
+    return;
+  }
+
   if (request.mode === 'navigate') {
     event.respondWith(handleNavigate(request));
     return;
@@ -63,14 +71,6 @@ self.addEventListener('fetch', (event) => {
     url.pathname.startsWith('/hls/')
   ) {
     event.respondWith(staleWhileRevalidate(request));
-    return;
-  }
-
-  if (
-    url.pathname.startsWith('/download') ||
-    url.pathname.startsWith('/shared/download')
-  ) {
-    event.respondWith(fetch(request));
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure `/download` paths are fetched directly instead of going through handleNavigate
- add regression test for order of service worker checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875d9800b30832cbd8cd7764a9886c5