### PR TITLE
Improve mobile dark mode and expiration visibility

### DIFF
--- a/tests/test_mobile_dark_mode.py
+++ b/tests/test_mobile_dark_mode.py
@@ -24,6 +24,15 @@ def test_phone_css_has_dark_mode_rules():
     text = CSS_PHONE.read_text(encoding='utf-8')
     assert 'body.dark-mode' in text
 
+def test_mobile_templates_have_fouc_script():
+    phone = BASE_PHONE.read_text(encoding='utf-8')
+    mobile = BASE_MOBILE.read_text(encoding='utf-8')
+    friendly = BASE_FRIENDLY.read_text(encoding='utf-8')
+    snippet = 'prefers-color-scheme: dark'
+    assert snippet in phone
+    assert snippet in mobile
+    assert snippet in friendly
+
 def test_mobile_css_has_dark_filename_rule():
     text = CSS_MOBILE.read_text(encoding='utf-8')
     assert 'body.dark-mode .file-card .file-name' in text
@@ -35,3 +44,12 @@ def test_friendly_css_has_dark_filename_rule():
 def test_phone_css_has_dark_filename_rule():
     text = CSS_PHONE.read_text(encoding='utf-8')
     assert 'body.dark-mode .file-card .file-name' in text
+
+def test_css_has_dark_expiration_rule():
+    phone_css = CSS_PHONE.read_text(encoding='utf-8')
+    mobile_css = CSS_MOBILE.read_text(encoding='utf-8')
+    friendly_css = CSS_FRIENDLY.read_text(encoding='utf-8')
+    snippet = 'body.dark-mode .expiration-cell small'
+    assert snippet in phone_css
+    assert snippet in mobile_css
+    assert snippet in friendly_css

--- a/tests/test_mobile_dark_mode.py
+++ b/tests/test_mobile_dark_mode.py
@@ -62,3 +62,12 @@ def test_css_has_dark_list_group_rule():
     assert snippet in phone_css
     assert snippet in mobile_css
     assert snippet in friendly_css
+
+def test_css_has_dark_send_modal_rule():
+    phone_css = CSS_PHONE.read_text(encoding='utf-8')
+    mobile_css = CSS_MOBILE.read_text(encoding='utf-8')
+    friendly_css = CSS_FRIENDLY.read_text(encoding='utf-8')
+    snippet = 'body.dark-mode #sendModal .form-select'
+    assert snippet in phone_css
+    assert snippet in mobile_css
+    assert snippet in friendly_css

--- a/tests/test_mobile_dark_mode.py
+++ b/tests/test_mobile_dark_mode.py
@@ -53,3 +53,12 @@ def test_css_has_dark_expiration_rule():
     assert snippet in phone_css
     assert snippet in mobile_css
     assert snippet in friendly_css
+
+def test_css_has_dark_list_group_rule():
+    phone_css = CSS_PHONE.read_text(encoding='utf-8')
+    mobile_css = CSS_MOBILE.read_text(encoding='utf-8')
+    friendly_css = CSS_FRIENDLY.read_text(encoding='utf-8')
+    snippet = 'body.dark-mode .list-group-item'
+    assert snippet in phone_css
+    assert snippet in mobile_css
+    assert snippet in friendly_css

--- a/tests/test_shared_dark_mode.py
+++ b/tests/test_shared_dark_mode.py
@@ -7,3 +7,7 @@ def test_shared_index_dark_mode_link_color():
     text = CSS_PATH.read_text(encoding='utf-8')
     assert 'body.dark-mode a.list-group-item-action' in text
     assert 'var(--text-color-dark)' in text
+
+def test_expiration_text_dark_mode_color():
+    text = CSS_PATH.read_text(encoding='utf-8')
+    assert 'body.dark-mode .expiration-cell small' in text

--- a/web/static/css/style-fresh.css
+++ b/web/static/css/style-fresh.css
@@ -427,3 +427,11 @@ body.dark-mode #fileSearch {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* 残り期限を改行付きで表示する */
+.expiration-cell small {
+  white-space: pre-line;
+}
+body.dark-mode .expiration-cell small {
+  color: var(--text-color-dark);
+}

--- a/web/static/css/style-mobile-friendly.css
+++ b/web/static/css/style-mobile-friendly.css
@@ -46,3 +46,6 @@ body.dark-mode .btn:hover {
 body.dark-mode .file-card .file-name {
   color: #f5f5f5;
 }
+body.dark-mode .expiration-cell small {
+  color: #f5f5f5;
+}

--- a/web/static/css/style-mobile-friendly.css
+++ b/web/static/css/style-mobile-friendly.css
@@ -63,3 +63,15 @@ body.dark-mode .list-group-item:last-child {
 body.dark-mode .list-group-item:hover {
   background-color: #35373f;
 }
+
+/* Send Modal Dark Mode */
+body.dark-mode #sendModal .modal-content {
+  background-color: #3a3c45;
+  color: #ffffff;
+}
+body.dark-mode #sendModal .form-select,
+body.dark-mode #sendModal .form-control {
+  background-color: #3a3c45;
+  color: #ffffff;
+  border-color: #444556;
+}

--- a/web/static/css/style-mobile-friendly.css
+++ b/web/static/css/style-mobile-friendly.css
@@ -49,3 +49,17 @@ body.dark-mode .file-card .file-name {
 body.dark-mode .expiration-cell small {
   color: #f5f5f5;
 }
+body.dark-mode .list-group {
+  border-color: #444556;
+}
+body.dark-mode .list-group-item {
+  background-color: #2e3038;
+  color: #f5f5f5;
+  border-bottom: 1px solid #444556;
+}
+body.dark-mode .list-group-item:last-child {
+  border-bottom: none;
+}
+body.dark-mode .list-group-item:hover {
+  background-color: #35373f;
+}

--- a/web/static/css/style-mobile.css
+++ b/web/static/css/style-mobile.css
@@ -46,3 +46,6 @@ body.dark-mode .btn:hover {
 body.dark-mode .file-card .file-name {
   color: #f5f5f5;
 }
+body.dark-mode .expiration-cell small {
+  color: #f5f5f5;
+}

--- a/web/static/css/style-mobile.css
+++ b/web/static/css/style-mobile.css
@@ -63,3 +63,15 @@ body.dark-mode .list-group-item:last-child {
 body.dark-mode .list-group-item:hover {
   background-color: #35373f;
 }
+
+/* Send Modal Dark Mode */
+body.dark-mode #sendModal .modal-content {
+  background-color: #3a3c45;
+  color: #ffffff;
+}
+body.dark-mode #sendModal .form-select,
+body.dark-mode #sendModal .form-control {
+  background-color: #3a3c45;
+  color: #ffffff;
+  border-color: #444556;
+}

--- a/web/static/css/style-mobile.css
+++ b/web/static/css/style-mobile.css
@@ -49,3 +49,17 @@ body.dark-mode .file-card .file-name {
 body.dark-mode .expiration-cell small {
   color: #f5f5f5;
 }
+body.dark-mode .list-group {
+  border-color: #444556;
+}
+body.dark-mode .list-group-item {
+  background-color: #2e3038;
+  color: #f5f5f5;
+  border-bottom: 1px solid #444556;
+}
+body.dark-mode .list-group-item:last-child {
+  border-bottom: none;
+}
+body.dark-mode .list-group-item:hover {
+  background-color: #35373f;
+}

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -156,3 +156,15 @@ body.dark-mode .list-group-item:last-child {
 body.dark-mode .list-group-item:hover {
   background-color: #35373f;
 }
+
+/* Send Modal Dark Mode */
+body.dark-mode #sendModal .modal-content {
+  background-color: #3a3c45;
+  color: #ffffff;
+}
+body.dark-mode #sendModal .form-select,
+body.dark-mode #sendModal .form-control {
+  background-color: #3a3c45;
+  color: #ffffff;
+  border-color: #444556;
+}

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -139,3 +139,6 @@ body.dark-mode .form-control:focus {
 body.dark-mode .file-card .file-name {
   color: #f5f5f5;
 }
+body.dark-mode .expiration-cell small {
+  color: #f5f5f5;
+}

--- a/web/static/css/style-phone.css
+++ b/web/static/css/style-phone.css
@@ -142,3 +142,17 @@ body.dark-mode .file-card .file-name {
 body.dark-mode .expiration-cell small {
   color: #f5f5f5;
 }
+body.dark-mode .list-group {
+  border-color: #444556;
+}
+body.dark-mode .list-group-item {
+  background-color: #2e3038;
+  color: #f5f5f5;
+  border-bottom: 1px solid #444556;
+}
+body.dark-mode .list-group-item:last-child {
+  border-bottom: none;
+}
+body.dark-mode .list-group-item:hover {
+  background-color: #35373f;
+}

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -401,3 +401,6 @@ body.dark-mode #fileSearch {
 .expiration-cell small {
   white-space: pre-line;
 }
+body.dark-mode .expiration-cell small {
+  color: var(--text-color-dark);
+}

--- a/web/templates/mobile/base_friendly.html
+++ b/web/templates/mobile/base_friendly.html
@@ -14,6 +14,14 @@
   {% block extra_meta %}{% endblock %}
 </head>
 <body>
+<!-- FOUC 対策：CSS 読み込み前に body.dark-mode を付与 -->
+<script>
+    const theme       = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (theme === 'dark' || (theme === null && prefersDark)) {
+      document.body.classList.add('dark-mode');
+    }
+</script>
 <nav class="navbar navbar-dark bg-primary py-2">
   <div class="container-fluid d-flex align-items-center justify-content-between">
     <span class="navbar-brand mb-0 h1">WDS</span>

--- a/web/templates/mobile/base_mobile.html
+++ b/web/templates/mobile/base_mobile.html
@@ -16,6 +16,14 @@
   {% block extra_meta %}{% endblock %}
 </head>
 <body>
+<!-- FOUC 対策：CSS 読み込み前に body.dark-mode を付与 -->
+<script>
+    const theme       = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (theme === 'dark' || (theme === null && prefersDark)) {
+      document.body.classList.add('dark-mode');
+    }
+</script>
 <nav class="navbar navbar-dark bg-dark">
   <div class="container-fluid d-flex align-items-center justify-content-between">
     <span class="navbar-brand">WDS</span>

--- a/web/templates/mobile/base_phone.html
+++ b/web/templates/mobile/base_phone.html
@@ -15,6 +15,14 @@
   {% block extra_meta %}{% endblock %}
 </head>
 <body>
+<!-- FOUC 対策：CSS 読み込み前に body.dark-mode を付与 -->
+<script>
+    const theme       = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (theme === 'dark' || (theme === null && prefersDark)) {
+      document.body.classList.add('dark-mode');
+    }
+</script>
 <nav class="navbar navbar-dark bg-dark">
   <div class="container-fluid d-flex align-items-center justify-content-between">
     <span class="navbar-brand">WDS</span>


### PR DESCRIPTION
## Summary
- apply FOUC avoidance dark-mode script to mobile base templates
- make expiration text readable on dark mode
- test for mobile dark mode features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875ded989c0832cb00ec4421f145819